### PR TITLE
Setup CI software build

### DIFF
--- a/.github/workflows/software_ci.yml
+++ b/.github/workflows/software_ci.yml
@@ -1,0 +1,24 @@
+name: Build software
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - aqt
+jobs:
+  build:
+    name: Build software
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+      - name: Build AQT tester software
+        run: |
+          nix build .#artiq-software-aqt-tester
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aqt-tester-software
+          path: |
+            result/runtime.elf
+            result/runtime.fbi

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ __pycache__/
 /dataset_db.mdb-lock
 /device_db*.py
 /test*
+result

--- a/aqt.json
+++ b/aqt.json
@@ -1,0 +1,9 @@
+{
+    "_description": "AQT tester",
+    "target": "kasli",
+    "variant": "aqt",
+    "min_artiq_version": "7.0",
+    "hw_rev": "v2.0",
+    "base": "standalone",
+    "peripherals": []
+}


### PR DESCRIPTION
## Summary

Basic CI setup that builds the ARTIQ coredevice software (firmware) for a dummy Kasli target.

To build locally, use:

```bash
nix build .#artiq-software-aqt-tester
```

It is recommended to use the [nix-output-monitor](https://github.com/maralorn/nix-output-monitor) for better CLI experience when building.

## Details

New Nix flake outputs:

- `artiq-board-aqt-tester`: standard ARTIQ build, including coredevice gateware and software.
- `artiq-software-aqt-tester`: software-only build. The new `artiq-software-src` derivation provides the ARTIQ source as Python package with the minimum dependencies to build the software. The Python package is necessary because of the way the standard ARTIQ build system is designed.

The software build takes around 3 min on the standard Ubuntu runner. All the Nix dependencies are pulled from binary caches (mostly `cache.nixos.org`). A dedicated cache would only allow caching the Rust dependencies, which are only a handful.