### PR TITLE
Upgrade rust compiler to 1.57 nightly.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       artiqVersion = (builtins.toString artiqVersionMajor) + "." + (builtins.toString artiqVersionMinor) + "+" + artiqVersionId + ".beta";
       artiqRev = self.sourceInfo.rev or "unknown";
 
-      rust = pkgs.rust-bin.nightly."2021-09-01".default.override {
+      rust = pkgs.rust-bin.nightly."2021-10-01".default.override {
         extensions = [ "rust-src" ];
         targets = [ ];
       };


### PR DESCRIPTION
## Summary

Upgrade the Rust compiler to 1.57 nightly.

This is done to allow using the 2021 edition that was stabilized in Rust 1.56. The previous nightly was a 1.56 nightly and thus didn't have a stable 2021 feature.

The exact nightly selected just happens to work. Tested on hardware.