### PR TITLE
ksupport: add ttl_out syscalls

### DIFF
--- a/aqt.json
+++ b/aqt.json
@@ -5,5 +5,15 @@
     "min_artiq_version": "7.0",
     "hw_rev": "v2.0",
     "base": "standalone",
-    "peripherals": []
+    "peripherals": [
+	{
+	    "type": "dio",
+	    "board": "DIO_BNC",
+	    "ports": [
+		0
+	    ],
+	    "bank_direction_low": "output",
+	    "bank_direction_high": "output"
+	}
+    ]
 }

--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -257,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
 name = "failure"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,9 +399,13 @@ dependencies = [
  "dyld",
  "eh",
  "io",
+ "itertools",
  "libc 0.1.0",
+ "prettyplease",
  "proto_artiq",
+ "quote 1.0.36",
  "riscv",
+ "syn 2.0.56",
  "unwind",
 ]
 
@@ -529,6 +548,16 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.56",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,10 +87,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "board_artiq"
 version = "0.0.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "board_misoc",
  "build_misoc",
  "byteorder",
@@ -212,6 +224,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8cb7306107e4b10e64994de6d3274bd08996a7c1322a27b86482392f96be0a"
 
 [[package]]
+name = "ddb_parser"
+version = "0.1.0"
+dependencies = [
+ "indoc",
+ "pyo3",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "dlmalloc"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,8 +268,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 dependencies = [
- "quote",
- "syn",
+ "quote 0.3.15",
+ "syn 0.11.11",
  "synstructure",
 ]
 
@@ -329,6 +352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "io"
 version = "0.0.0"
 dependencies = [
@@ -338,6 +367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "ksupport"
 version = "0.0.0"
 dependencies = [
@@ -345,6 +380,7 @@ dependencies = [
  "board_misoc",
  "build_misoc",
  "cslice",
+ "ddb_parser",
  "dyld",
  "eh",
  "io",
@@ -369,6 +405,16 @@ name = "libc"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -413,6 +459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +502,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc 0.2.99",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "git+https://github.com/airwoodix/proc-macro2?branch=is-available-nightly-unstable#d9ce012aa981c2251cd9bbdf9c838d25245fb6c7"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "proto_artiq"
 version = "0.0.0"
 dependencies = [
@@ -461,10 +553,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc 0.2.99",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+dependencies = [
+ "libc 0.2.99",
+ "pyo3-build-config",
+]
+
+[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+dependencies = [
+ "bitflags 2.5.0",
+]
 
 [[package]]
 name = "regex"
@@ -546,6 +691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "satman"
 version = "0.0.0"
 dependencies = [
@@ -560,6 +711,12 @@ dependencies = [
  "proto_artiq",
  "riscv",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -577,6 +734,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.56",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,7 +776,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee34c1e1bfc7e9206cc0fb8030a90129b4e319ab53856249bb27642cab914fb3"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "managed 0.8.0",
 ]
@@ -605,9 +793,20 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 dependencies = [
- "quote",
+ "quote 0.3.15",
  "synom",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2415488199887523e74fd9a5f7be804dfd42d868ae0eca382e3917094d210e"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -625,8 +824,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 dependencies = [
- "quote",
- "syn",
+ "quote 0.3.15",
+ "syn 0.11.11",
 ]
 
 [[package]]
@@ -635,9 +834,41 @@ version = "0.1.8"
 source = "git+https://git.m-labs.hk/M-Labs/tar-no-std?rev=2ab6dc5#2ab6dc58e5249c59c4eb03eaf3a119bcdd678d32"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.3.2",
  "log",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.56",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-width"
@@ -678,3 +909,67 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/artiq/firmware/Cargo.toml
+++ b/artiq/firmware/Cargo.toml
@@ -5,3 +5,6 @@ members = ["bootloader", "runtime", "ksupport", "satman"]
 incremental = false # incompatible with LTO
 lto = true
 debug = 2
+
+[patch.crates-io]
+proc-macro2 = { git = "https://github.com/airwoodix/proc-macro2", branch="is-available-nightly-unstable" }

--- a/artiq/firmware/ddb_parser/Cargo.toml
+++ b/artiq/firmware/ddb_parser/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ddb_parser"
+description = "ARTIQ device_db parser."
+authors = ["Alpine Quantum Technologies GmbH <info@aqt.eu>"]
+license = "MIT"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+indoc = "2"
+pyo3 = { version = "0.20", features = ["auto-initialize"], default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"

--- a/artiq/firmware/ddb_parser/src/devices.rs
+++ b/artiq/firmware/ddb_parser/src/devices.rs
@@ -1,0 +1,103 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "_qualclass")]
+pub enum Device {
+    #[serde(rename = "artiq.coredevice.core.Core")]
+    Core { arguments: Core },
+    #[serde(rename = "artiq.coredevice.cache.CoreCache")]
+    CoreCache {},
+    #[serde(rename = "artiq.coredevice.dma.CoreDMA")]
+    CoreDma {},
+    #[serde(rename = "artiq.coredevice.i2c.I2CSwitch")]
+    I2cSwitch { arguments: I2cSwitch },
+    #[serde(rename = "artiq.coredevice.ttl.TTLOut")]
+    TtlOut { arguments: TtlOut },
+    #[serde(rename = "artiq.coredevice.ttl.TTLInOut")]
+    TtlInOut { arguments: TtlInOut },
+    #[serde(rename = "artiq.coredevice.ttl.TTLClockGen")]
+    TtlClockGen { arguments: TtlClockGen },
+    #[serde(rename = "artiq.coredevice.edge_counter.EdgeCounter")]
+    EdgeCounter { arguments: EdgeCounter },
+    #[serde(rename = "artiq.coredevice.urukul.CPLD")]
+    UrukulCpld { arguments: UrukulCpld },
+    #[serde(rename = "artiq.coredevice.phaser.Phaser")]
+    Phaser { arguments: Phaser },
+
+    #[serde(untagged)]
+    Unknown(Ignored),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Core {
+    pub host: String,
+    pub ref_period: f32,
+    pub ref_multiplier: Option<i32>,
+    pub target: Option<Target>,
+}
+
+#[derive(Debug, Deserialize)]
+pub enum Target {
+    #[serde(rename = "rv32ima")]
+    Kasli1,
+    #[serde(rename = "rv32g")]
+    Kasli2,
+    #[serde(rename = "cortexa9")]
+    KasliSoc,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct I2cSwitch {
+    pub busno: Option<i32>,
+    pub address: Option<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TtlOut {
+    pub channel: i32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TtlInOut {
+    pub channel: i32,
+    pub gate_latency_mu: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TtlClockGen {
+    pub channel: i32,
+    pub acc_width: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EdgeCounter {
+    pub channel: i32,
+    pub gateware_width: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UrukulCpld {
+    pub spi_device: String,
+    pub io_update_device: Option<String>,
+    pub dds_reset_device: Option<String>,
+    pub sync_device: Option<String>,
+    pub sync_sel: Option<u8>,
+    pub clk_sel: Option<u8>,
+    pub clk_div: Option<u8>,
+    pub rf_sw: Option<u8>,
+    pub refclk: Option<f64>,
+    pub att: Option<u32>,
+    pub sync_div: Option<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Phaser {
+    pub channel_base: i32,
+    pub miso_delay: Option<i32>,
+    pub tune_fifo_offset: Option<bool>,
+    pub clk_sel: Option<u8>,
+    pub sync_dly: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Ignored {}

--- a/artiq/firmware/ddb_parser/src/lib.rs
+++ b/artiq/firmware/ddb_parser/src/lib.rs
@@ -1,0 +1,51 @@
+use thiserror::Error;
+
+use indoc::indoc;
+use pyo3::types::{PyDict, PyModule};
+use std::collections::HashMap;
+
+mod devices;
+pub use devices::Device;
+
+pub type DeviceDb = HashMap<String, Device>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("type error: {0}")]
+    Type(String),
+    #[error(transparent)]
+    Python(#[from] pyo3::PyErr),
+    #[error(transparent)]
+    Parse(#[from] serde_json::Error),
+}
+
+pub fn parse(python_code: &str) -> Result<DeviceDb, Error> {
+    pyo3::Python::with_gil(|py| {
+        let module = PyModule::from_code(py, python_code, "device_db.py", "device_db")?;
+        let ddb = module
+            .getattr("device_db")?
+            .downcast::<PyDict>()
+            .map_err(|_| Error::Type("device_db is not a PyDict".into()))?;
+
+        let pp_module =
+            PyModule::from_code(py, PREPROCESSING_CODE, "preprocessing.py", "preprocessing")?;
+
+        let json: String = pp_module.getattr("preprocess")?.call1((ddb,))?.extract()?;
+        let ddb: DeviceDb = serde_json::from_str(&json)?;
+
+        Ok(ddb)
+    })
+}
+
+const PREPROCESSING_CODE: &str = indoc! {r#"
+      import json
+
+      def add_qual_class(entry):
+          if (module := entry.get("module")) and (class_ := entry.get("class")):
+              entry["_qualclass"] = f"{module}.{class_}"
+          return entry
+
+      def preprocess(ddb):
+          return json.dumps({key: add_qual_class(value) for key, value in ddb.items()})
+      "#
+};

--- a/artiq/firmware/ddb_parser/src/lib.rs
+++ b/artiq/firmware/ddb_parser/src/lib.rs
@@ -40,12 +40,12 @@ pub fn parse(python_code: &str) -> Result<DeviceDb, Error> {
 const PREPROCESSING_CODE: &str = indoc! {r#"
       import json
 
-      def add_qual_class(entry):
+      def add_qual_class(entry: dict) -> dict:
           if (module := entry.get("module")) and (class_ := entry.get("class")):
               entry["_qualclass"] = f"{module}.{class_}"
           return entry
 
-      def preprocess(ddb):
+      def preprocess(ddb: dict) -> str:
           return json.dumps({key: add_qual_class(value) for key, value in ddb.items()})
       "#
 };

--- a/artiq/firmware/ddb_parser/src/lib.rs
+++ b/artiq/firmware/ddb_parser/src/lib.rs
@@ -31,9 +31,7 @@ pub fn parse(python_code: &str) -> Result<DeviceDb, Error> {
             PyModule::from_code(py, PREPROCESSING_CODE, "preprocessing.py", "preprocessing")?;
 
         let json: String = pp_module.getattr("preprocess")?.call1((ddb,))?.extract()?;
-        let ddb: DeviceDb = serde_json::from_str(&json)?;
-
-        Ok(ddb)
+        Ok(serde_json::from_str(&json)?)
     })
 }
 

--- a/artiq/firmware/ksupport/Cargo.toml
+++ b/artiq/firmware/ksupport/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["staticlib"]
 
 [build-dependencies]
 build_misoc = { path = "../libbuild_misoc" }
+ddb_parser = { path = "../ddb_parser" }
 
 [dependencies]
 cslice = { version = "0.3" }

--- a/artiq/firmware/ksupport/Cargo.toml
+++ b/artiq/firmware/ksupport/Cargo.toml
@@ -12,6 +12,10 @@ crate-type = ["staticlib"]
 [build-dependencies]
 build_misoc = { path = "../libbuild_misoc" }
 ddb_parser = { path = "../ddb_parser" }
+itertools = "0.12"
+prettyplease = "0.2.16"
+quote = "1"
+syn = "2"
 
 [dependencies]
 cslice = { version = "0.3" }

--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -187,4 +187,10 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(spi_set_config = ::nrt_bus::spi::set_config),
     api!(spi_write = ::nrt_bus::spi::write),
     api!(spi_read = ::nrt_bus::spi::read),
+    /* Sinara */
+    api!(ttl_out_count = ::sinara::ttl_out_count),
+    #[cfg(has_sinara_ttl_out)]
+    api!(ttl_out_on = ::sinara::ttl_out_on),
+    #[cfg(has_sinara_ttl_out)]
+    api!(ttl_out_off = ::sinara::ttl_out_off),
 ];

--- a/artiq/firmware/ksupport/build.rs
+++ b/artiq/firmware/ksupport/build.rs
@@ -1,6 +1,17 @@
-extern crate build_misoc;
+use std::path::Path;
+use std::{env, fs};
 
 fn main() {
+    let buildinc_dir = env::var("BUILDINC_DIRECTORY").unwrap();
+    let ddb_path = Path::new(&buildinc_dir)
+        .join("generated")
+        .join("device_db.py");
+    println!("cargo:rerun-if-changed={}", ddb_path.to_str().unwrap());
+
+    let ddb = fs::read_to_string(&ddb_path).unwrap();
+    let _ = ddb_parser::parse(&ddb).unwrap();
+    // TODO: emit peripherals instantiation code
+
     build_misoc::cfg();
     println!("cargo:rustc-cfg={}", "ksupport");
 }

--- a/artiq/firmware/ksupport/build.rs
+++ b/artiq/firmware/ksupport/build.rs
@@ -28,8 +28,8 @@ fn main() {
         .join("device_db.py");
     println!("cargo:rerun-if-changed={}", ddb_path.to_str().unwrap());
 
-    let ddb = fs::read_to_string(&ddb_path).unwrap();
-    let ddb = ddb_parser::parse(&ddb).unwrap();
+    let ddb_py = fs::read_to_string(&ddb_path).unwrap();
+    let ddb = ddb_parser::parse(&ddb_py).unwrap();
 
     let ttl_out_channels: Vec<_> = ddb
         .iter()

--- a/artiq/firmware/ksupport/build.rs
+++ b/artiq/firmware/ksupport/build.rs
@@ -1,7 +1,27 @@
+extern crate ddb_parser;
+extern crate itertools;
+extern crate prettyplease;
+extern crate quote;
+extern crate syn;
+
+use ddb_parser::Device;
 use std::path::Path;
 use std::{env, fs};
 
+use itertools::Itertools;
+use quote::quote;
+
+/// Configuration and code generation for the kernel-support library.
+///
+/// - pass the configuration options set by the SoC definition.
+/// - parse the generated device DB, extract the available peripherals.
+/// - emit code for the `PERIPHERALS` data in the `sinara` module.
+/// - set configuration options for the available channel types. These gate the
+///   compilation of the corresponding syscalls.
 fn main() {
+    build_misoc::cfg();
+    println!("cargo:rustc-cfg={}", "ksupport");
+
     let buildinc_dir = env::var("BUILDINC_DIRECTORY").unwrap();
     let ddb_path = Path::new(&buildinc_dir)
         .join("generated")
@@ -9,9 +29,43 @@ fn main() {
     println!("cargo:rerun-if-changed={}", ddb_path.to_str().unwrap());
 
     let ddb = fs::read_to_string(&ddb_path).unwrap();
-    let _ = ddb_parser::parse(&ddb).unwrap();
-    // TODO: emit peripherals instantiation code
+    let ddb = ddb_parser::parse(&ddb).unwrap();
 
-    build_misoc::cfg();
-    println!("cargo:rustc-cfg={}", "ksupport");
+    let ttl_out_channels: Vec<_> = ddb
+        .iter()
+        .filter_map(|elem| match elem {
+            (key, Device::TtlOut { arguments }) => {
+                if key.contains("ttl") {
+                    Some(arguments.channel)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .sorted()
+        .collect();
+
+    let num_ttl_out_channels = ttl_out_channels.len();
+    if num_ttl_out_channels > 0 {
+        println!("cargo:rustc-cfg={}", "has_sinara_ttl_out");
+    }
+
+    #[rustfmt::skip]
+    let output = quote! {
+	pub struct Peripherals {
+            ttl_out: [ttl::TtlOut; #num_ttl_out_channels],
+	}
+
+	pub const PERIPHERALS: Peripherals = Peripherals {
+            ttl_out: [#( ttl::TtlOut { channel: #ttl_out_channels } ),*],
+	};
+    };
+
+    let syntax_tree = syn::parse2(output).unwrap();
+    let formatted = prettyplease::unparse(&syntax_tree);
+
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("peripherals.rs");
+    fs::write(dest_path, formatted).unwrap();
 }

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -110,6 +110,7 @@ mod api;
 mod eh_artiq;
 mod nrt_bus;
 mod rtio;
+mod sinara;
 
 static mut LIBRARY: Option<Library<'static>> = None;
 

--- a/artiq/firmware/ksupport/sinara/mod.rs
+++ b/artiq/firmware/ksupport/sinara/mod.rs
@@ -1,0 +1,21 @@
+#[cfg(not(has_rtio))]
+compile_error!("Need RTIO to use Sinara drivers");
+
+pub mod ttl;
+
+include!(concat!(env!("OUT_DIR"), "/peripherals.rs"));
+
+/* Syscalls */
+#[cfg(has_sinara_ttl_out)]
+pub extern "C" fn ttl_out_on(channel: usize) {
+    PERIPHERALS.ttl_out[channel].on()
+}
+
+#[cfg(has_sinara_ttl_out)]
+pub extern "C" fn ttl_out_off(channel: usize) {
+    PERIPHERALS.ttl_out[channel].off()
+}
+
+pub extern "C" fn ttl_out_count() -> usize {
+    PERIPHERALS.ttl_out.len()
+}

--- a/artiq/firmware/ksupport/sinara/ttl.rs
+++ b/artiq/firmware/ksupport/sinara/ttl.rs
@@ -1,0 +1,22 @@
+use crate::rtio;
+
+pub struct TtlOut {
+    pub channel: i32,
+}
+
+impl TtlOut {
+    #[allow(dead_code)]
+    pub fn output(&self) {}
+
+    pub fn on(&self) {
+        self.set_o(true)
+    }
+
+    pub fn off(&self) {
+        self.set_o(false)
+    }
+
+    fn set_o(&self, o: bool) {
+        rtio::output(self.channel << 8, if o { 1 } else { 0 })
+    }
+}

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -848,6 +848,9 @@ def main():
     if description["enable_wrpll"] and description["hw_rev"] in ["v1.0", "v1.1"]:
         raise ValueError("Kasli {} does not support WRPLL".format(description["hw_rev"])) 
 
+    soc = cls(description, gateware_identifier_str=args.gateware_identifier_str, **soc_kasli_argdict(args))
+
+    args.variant = description["variant"]
     build_args = builder_argdict(args)
 
     # This path must match the hardcoded BUILDINC_DIRECTORY in misoc:
@@ -860,8 +863,6 @@ def main():
         artiq_ddb_template.process(f, description, [])
     print(f"Device DB written to: {ddb_path.resolve()}")
 
-    soc = cls(description, gateware_identifier_str=args.gateware_identifier_str, **soc_kasli_argdict(args))
-    args.variant = description["variant"]
     build_artiq_soc(soc, build_args)
 
 

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 from packaging.version import Version
+from pathlib import Path
 
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
@@ -29,6 +30,7 @@ from artiq.gateware.drtio import *
 from artiq.gateware.wrpll import wrpll
 from artiq.build_soc import *
 from artiq.coredevice import jsondesc
+from artiq.frontend import artiq_ddb_template
 
 logger = logging.getLogger(__name__)
 
@@ -846,9 +848,21 @@ def main():
     if description["enable_wrpll"] and description["hw_rev"] in ["v1.0", "v1.1"]:
         raise ValueError("Kasli {} does not support WRPLL".format(description["hw_rev"])) 
 
+    build_args = builder_argdict(args)
+
+    # This path must match the hardcoded BUILDINC_DIRECTORY in misoc:
+    buildinc_directory = Path(build_args["output_dir"]) / "software" / "include"
+
+    # Generate device_db (satellites not supported!)
+    ddb_path = buildinc_directory / "generated" / "device_db.py"
+    ddb_path.parent.mkdir(parents=True, exist_ok=True)
+    with ddb_path.open("w") as f:
+        artiq_ddb_template.process(f, description, [])
+    print(f"Device DB written to: {ddb_path.resolve()}")
+
     soc = cls(description, gateware_identifier_str=args.gateware_identifier_str, **soc_kasli_argdict(args))
     args.variant = description["variant"]
-    build_artiq_soc(soc, builder_argdict(args))
+    build_artiq_soc(soc, build_args)
 
 
 if __name__ == "__main__":

--- a/flake.nix
+++ b/flake.nix
@@ -225,6 +225,15 @@
         runScript = "vivado";
       };
 
+      firmwareCargoDeps = rustPlatform.importCargoLock {
+        lockFile = ./artiq/firmware/Cargo.lock;
+        outputHashes = {
+          "fringe-1.2.1" = "sha256-u7NyZBzGrMii79V+Xs4Dx9tCpiby6p8IumkUl7oGBm0=";
+          "tar-no-std-0.1.8" = "sha256-xm17108v4smXOqxdLvHl9CxTCJslmeogjm4Y87IXFuM=";
+          "proc-macro2-1.0.86" = "sha256-bK0ls5ni9TyMB2xyi4wMFyIFD7v+pTKE55uqhQBsusg=";
+        };
+      };
+
       # ARTIQ source for software builds.
       artiq-software-src = pkgs.python3Packages.buildPythonPackage rec {
         pname = "artiq";
@@ -254,13 +263,7 @@
         pkgs.stdenv.mkDerivation {
           name = "artiq-software-kasli-${variant}";
           phases = ["buildPhase" "installPhase"];
-          cargoDeps = rustPlatform.importCargoLock {
-            lockFile = ./artiq/firmware/Cargo.lock;
-            outputHashes = {
-              "fringe-1.2.1" = "sha256-u7NyZBzGrMii79V+Xs4Dx9tCpiby6p8IumkUl7oGBm0=";
-              "tar-no-std-0.1.8" = "sha256-xm17108v4smXOqxdLvHl9CxTCJslmeogjm4Y87IXFuM=";
-            };
-          };
+          cargoDeps = firmwareCargoDeps;
 
           nativeBuildInputs = [
             (pkgs.python3.withPackages(ps: [
@@ -298,13 +301,8 @@
         pkgs.stdenv.mkDerivation {
           name = "artiq-board-${target}-${variant}";
           phases = [ "buildPhase" "checkPhase" "installPhase" ];
-          cargoDeps = rustPlatform.importCargoLock {
-            lockFile = ./artiq/firmware/Cargo.lock;
-            outputHashes = {
-              "fringe-1.2.1" = "sha256-u7NyZBzGrMii79V+Xs4Dx9tCpiby6p8IumkUl7oGBm0=";
-              "tar-no-std-0.1.8" = "sha256-xm17108v4smXOqxdLvHl9CxTCJslmeogjm4Y87IXFuM=";
-            };
-          };
+          cargoDeps = firmwareCargoDeps;
+
           nativeBuildInputs = [
             (pkgs.python3.withPackages(ps: [ migen misoc (artiq.withExperimentalFeatures experimentalFeatures) ps.packaging ]))
             rust


### PR DESCRIPTION
## Summary

Add the following syscalls:

- `ttl_out_count`: number of TTL output (output only) channels.
- `ttl_out_on`: set a TTL output channel high.
- `ttl_out_off`: set a TTL output channel low.

To demonstrate the build system's features, the latter two syscalls are only included if there are some TTL output channels in the target description.

## Details

### Peripherals data structure

The `ksupport::sinara` module holds the `PERIPHERALS` data structure with all the peripherals' state. The data structure definition and instantiation code is generated at compilation time by introspecting the target hardware configuration.

### Code generation

The `PERIPHERALS` data structure is generated from reading the target's device DB and Rust code then included in the `ksupport::sinara` module.

Due to the relative old compiler used (1.57 nightly), the code generation utility [`genco`](https://github.com/udoprog/genco) cannot be used (MSRV is 1.66 in the usable versions). The code therefore falls back to the more basic [`quote`](https://crates.io/crates/quote) for the token stream generation.

The code generation is for the moment very rudimentary and meant to evolve significantly. Also the `PERIPHERALS` data structure is by no means stable.

### Device DB parser

The `ddb_parser` crate is a `std` crate that uses `pyo3` and `serde` to parse the device DB's Python representation into a Rust data structure.

### `proc-macro2` patch

The macro features in `serde` depend on [`proc-macro2`](https://crates.io/crates/proc-macro2) which uses a build-time switch to use the [`proc_macro_is_available`](https://github.com/rust-lang/rust/issues/71436) feature that was stabilized in Rust 1.57. However, since we use a 1.57 nightly build, the feature is available but unstable. A patched crate is used to enable the unstable feature flag in this edge case. The patch likely needs extra work to be upstreamed, if at all.