### PR TITLE
ddb_parser: add Urukul-related models

### DIFF
--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -263,6 +263,7 @@ name = "ddb_parser"
 version = "0.1.0"
 dependencies = [
  "indoc",
+ "num_enum",
  "pyo3",
  "serde",
  "serde_json",
@@ -555,6 +556,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.56",
+]
+
+[[package]]
 name = "object"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +629,16 @@ checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
  "syn 2.0.56",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -980,6 +1012,15 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.36",
  "syn 2.0.56",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -224,6 +224,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8cb7306107e4b10e64994de6d3274bd08996a7c1322a27b86482392f96be0a"
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote 1.0.36",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ddb_parser"
 version = "0.1.0"
 dependencies = [
@@ -231,6 +266,7 @@ dependencies = [
  "pyo3",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror",
 ]
 
@@ -296,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fortanix-sgx-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +398,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc 0.2.99",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indoc"
@@ -796,6 +844,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +889,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +903,17 @@ dependencies = [
  "quote 0.3.15",
  "synom",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/artiq/firmware/ddb_parser/Cargo.toml
+++ b/artiq/firmware/ddb_parser/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 indoc = "2"
+num_enum = "0.7.2"
 pyo3 = { version = "0.20", features = ["auto-initialize"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/artiq/firmware/ddb_parser/Cargo.toml
+++ b/artiq/firmware/ddb_parser/Cargo.toml
@@ -11,4 +11,5 @@ indoc = "2"
 pyo3 = { version = "0.20", features = ["auto-initialize"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_with = "1"
 thiserror = "1"

--- a/artiq/firmware/ddb_parser/src/devices.rs
+++ b/artiq/firmware/ddb_parser/src/devices.rs
@@ -1,4 +1,6 @@
+use crate::i2c;
 use serde::Deserialize;
+use serde_with::{serde_as, TryFromInto};
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "_qualclass")]
@@ -21,8 +23,14 @@ pub enum Device {
     EdgeCounter { arguments: EdgeCounter },
     #[serde(rename = "artiq.coredevice.urukul.CPLD")]
     UrukulCpld { arguments: UrukulCpld },
+    #[serde(rename = "artiq.coredevice.ad9910.AD9910")]
+    Ad9910 { arguments: Ad9910 },
     #[serde(rename = "artiq.coredevice.phaser.Phaser")]
     Phaser { arguments: Phaser },
+    #[serde(rename = "artiq.coredevice.spi2.SPIMaster")]
+    Spi2Master { arguments: Spi2Master },
+    #[serde(rename = "artiq.coredevice.kasli_i2c.KasliEEPROM")]
+    KasliEeprom { arguments: KasliEeprom },
 
     #[serde(untagged)]
     Unknown(Ignored),
@@ -90,6 +98,53 @@ pub struct UrukulCpld {
     pub sync_div: Option<u8>,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub struct Ad9910 {
+    pub cpld_device: String,
+    pub chip_select: i32,
+    pub sw_device: Option<String>,
+    pub pll_n: Option<i32>,
+    pub pll_cp: Option<i32>,  // TODO: use ad9910-pac type
+    pub pll_vco: Option<i32>, // TODO: use ad9910-pac type
+    pub sync_delay_seed: Option<MaybeOnEeprom>,
+    pub io_update_delay: Option<MaybeOnEeprom>,
+    #[serde(default)]
+    #[serde(deserialize_with = "optional_bool_from_int")]
+    pub pll_en: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum MaybeOnEeprom {
+    EepromAddress(EepromAddress),
+    Value(u32),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+#[serde(try_from = "String")]
+pub struct EepromAddress {
+    pub eeprom_device: String,
+    pub offset: u32,
+}
+
+impl TryFrom<String> for EepromAddress {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let parts: Vec<_> = value.split(':').collect();
+        if parts.len() != 2 {
+            return Err("Invalid EepromAddress format.".into());
+        }
+
+        Ok(Self {
+            eeprom_device: parts[0].into(),
+            offset: parts[1]
+                .parse::<_>()
+                .map_err(|e| format!("Invalid offset: {}", e))?,
+        })
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Phaser {
     pub channel_base: i32,
@@ -100,4 +155,173 @@ pub struct Phaser {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct Spi2Master {
+    pub channel: i32,
+    pub div: Option<i32>,
+    pub length: Option<i32>,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize, Clone)]
+pub struct KasliEeprom {
+    #[serde_as(as = "TryFromInto<&str>")]
+    pub port: i2c::KasliPort,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Ignored {}
+
+/// Deserialize optional booleans from integers.
+/// https://github.com/serde-rs/serde/issues/1344#issuecomment-410309140
+fn optional_bool_from_int<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    match Option::<u8>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(0) => Ok(Some(false)),
+        Some(1) => Ok(Some(true)),
+        Some(other) => Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(other as u64),
+            &"zero or one",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ad9910_typical() {
+        let data = r#"
+            {
+                "_qualclass": "artiq.coredevice.ad9910.AD9910",
+                "arguments": {
+                    "pll_en": 1,
+                    "pll_n": 32,
+                    "chip_select": 4,
+                    "cpld_device": "urukul0_cpld",
+                    "sw_device": "ttl_urukul0_sw0",
+                    "sync_delay_seed": "eeprom_urukul0:64",
+                    "io_update_delay": "eeprom_urukul0:68"
+                }
+           }
+        "#;
+
+        let dev: Device = serde_json::from_str(data).unwrap();
+
+        match dev {
+            Device::Ad9910 { arguments } => {
+                assert!(arguments.pll_en.unwrap());
+                assert_eq!(arguments.pll_n.unwrap(), 32);
+                assert_eq!(arguments.chip_select, 4);
+                assert_eq!(arguments.cpld_device, "urukul0_cpld");
+                assert_eq!(
+                    arguments.sync_delay_seed,
+                    Some(MaybeOnEeprom::EepromAddress(EepromAddress {
+                        eeprom_device: "eeprom_urukul0".into(),
+                        offset: 64,
+                    }))
+                );
+                assert_eq!(
+                    arguments.io_update_delay,
+                    Some(MaybeOnEeprom::EepromAddress(EepromAddress {
+                        eeprom_device: "eeprom_urukul0".into(),
+                        offset: 68,
+                    }))
+                );
+            }
+            _ => panic!("Must be Ad9910"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ad9910_no_pll_en() {
+        let data = r#"
+            {
+                "_qualclass": "artiq.coredevice.ad9910.AD9910",
+                "arguments": {
+                    "chip_select": 4,
+                    "cpld_device": "urukul0_cpld"
+                }
+           }
+        "#;
+
+        let dev: Device = serde_json::from_str(data).unwrap();
+
+        match dev {
+            Device::Ad9910 { arguments } => {
+                assert!(arguments.pll_en.is_none());
+            }
+            _ => panic!("Must be Ad9910."),
+        }
+    }
+
+    #[test]
+    fn test_parse_ad9910_pll_disabled() {
+        let data = r#"
+            {
+                "_qualclass": "artiq.coredevice.ad9910.AD9910",
+                "arguments": {
+                    "pll_en": 0,
+                    "chip_select": 4,
+                    "cpld_device": "urukul0_cpld"
+                }
+           }
+        "#;
+
+        let dev: Device = serde_json::from_str(data).unwrap();
+
+        match dev {
+            Device::Ad9910 { arguments } => {
+                assert_eq!(arguments.pll_en, Some(false));
+            }
+            _ => panic!("Must be Ad9910."),
+        }
+    }
+
+    #[test]
+    fn test_parse_ad9910_explicit_sync_delay_seed() {
+        let data = r#"
+            {
+                "_qualclass": "artiq.coredevice.ad9910.AD9910",
+                "arguments": {
+                    "chip_select": 4,
+                    "cpld_device": "urukul0_cpld",
+                    "sync_delay_seed": 32
+                }
+           }
+        "#;
+
+        let dev: Device = serde_json::from_str(data).unwrap();
+
+        match dev {
+            Device::Ad9910 { arguments } => {
+                assert_eq!(arguments.sync_delay_seed, Some(MaybeOnEeprom::Value(32)));
+            }
+            _ => panic!("Must be Ad9910."),
+        }
+    }
+
+    #[test]
+    fn test_parse_kasli_eeprom() {
+        let data = r#"
+            {
+                "_qualclass": "artiq.coredevice.kasli_i2c.KasliEEPROM",
+                "arguments": {
+                    "port": "EEM3"
+                }
+            }
+        "#;
+
+        let dev: Device = serde_json::from_str(data).unwrap();
+
+        match dev {
+            Device::KasliEeprom { arguments } => {
+                assert_eq!(arguments.port, i2c::KasliPort::Eem3)
+            }
+            _ => panic!("Must be KasliEEPROM."),
+        }
+    }
+}

--- a/artiq/firmware/ddb_parser/src/devices.rs
+++ b/artiq/firmware/ddb_parser/src/devices.rs
@@ -2,7 +2,7 @@ use crate::i2c;
 use serde::Deserialize;
 use serde_with::{serde_as, TryFromInto};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(tag = "_qualclass")]
 pub enum Device {
     #[serde(rename = "artiq.coredevice.core.Core")]
@@ -36,7 +36,7 @@ pub enum Device {
     Unknown(Ignored),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct Core {
     pub host: String,
     pub ref_period: f32,
@@ -44,7 +44,7 @@ pub struct Core {
     pub target: Option<Target>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub enum Target {
     #[serde(rename = "rv32ima")]
     Kasli1,
@@ -54,36 +54,36 @@ pub enum Target {
     KasliSoc,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct I2cSwitch {
     pub busno: Option<i32>,
     pub address: Option<u8>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct TtlOut {
     pub channel: i32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct TtlInOut {
     pub channel: i32,
     pub gate_latency_mu: Option<i32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct TtlClockGen {
     pub channel: i32,
     pub acc_width: Option<i32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct EdgeCounter {
     pub channel: i32,
     pub gateware_width: Option<i32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct UrukulCpld {
     pub spi_device: String,
     pub io_update_device: Option<String>,
@@ -98,7 +98,7 @@ pub struct UrukulCpld {
     pub sync_div: Option<u8>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct Ad9910 {
     pub cpld_device: String,
     pub chip_select: i32,
@@ -120,7 +120,7 @@ pub enum MaybeOnEeprom {
     Value(u32),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 #[serde(try_from = "String")]
 pub struct EepromAddress {
     pub eeprom_device: String,
@@ -145,7 +145,7 @@ impl TryFrom<String> for EepromAddress {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct Phaser {
     pub channel_base: i32,
     pub miso_delay: Option<i32>,
@@ -154,7 +154,7 @@ pub struct Phaser {
     pub sync_dly: Option<i32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct Spi2Master {
     pub channel: i32,
     pub div: Option<i32>,
@@ -162,13 +162,13 @@ pub struct Spi2Master {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct KasliEeprom {
     #[serde_as(as = "TryFromInto<&str>")]
     pub port: i2c::KasliPort,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct Ignored {}
 
 /// Deserialize optional booleans from integers.

--- a/artiq/firmware/ddb_parser/src/i2c.rs
+++ b/artiq/firmware/ddb_parser/src/i2c.rs
@@ -1,0 +1,55 @@
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[repr(u8)]
+pub enum KasliPort {
+    Eem0 = 7,
+    Eem1 = 5,
+    Eem2 = 4,
+    Eem3 = 3,
+    Eem4 = 2,
+    Eem5 = 1,
+    Eem6 = 0,
+    Eem7 = 6,
+    Eem8 = 12,
+    Eem9 = 13,
+    Eem10 = 15,
+    Eem11 = 14,
+    Sfp0 = 8,
+    Sfp1 = 9,
+    Sfp2 = 10,
+    Loc0 = 11,
+}
+
+impl<'a> TryFrom<&'a str> for KasliPort {
+    type Error = InvalidKasliPort<'a>;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        match s {
+            "EEM0" => Ok(Self::Eem0),
+            "EEM1" => Ok(Self::Eem1),
+            "EEM2" => Ok(Self::Eem2),
+            "EEM3" => Ok(Self::Eem3),
+            "EEM4" => Ok(Self::Eem4),
+            "EEM5" => Ok(Self::Eem5),
+            "EEM6" => Ok(Self::Eem6),
+            "EEM7" => Ok(Self::Eem7),
+            "EEM8" => Ok(Self::Eem8),
+            "EEM9" => Ok(Self::Eem9),
+            "EEM10" => Ok(Self::Eem10),
+            "EEM11" => Ok(Self::Eem11),
+            "SFP0" => Ok(Self::Sfp0),
+            "SFP1" => Ok(Self::Sfp1),
+            "SFP2" => Ok(Self::Sfp2),
+            "LOC0" => Ok(Self::Loc0),
+            _ => Err(InvalidKasliPort(s)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct InvalidKasliPort<'a>(&'a str);
+
+impl<'a> core::fmt::Display for InvalidKasliPort<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Invalid Kasli I2C port: {}", self.0)
+    }
+}

--- a/artiq/firmware/ddb_parser/src/i2c.rs
+++ b/artiq/firmware/ddb_parser/src/i2c.rs
@@ -1,4 +1,7 @@
-#[derive(Debug, Eq, PartialEq, Clone)]
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use std::fmt;
+
+#[derive(Debug, Eq, PartialEq, Clone, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum KasliPort {
     Eem0 = 7,
@@ -48,8 +51,8 @@ impl<'a> TryFrom<&'a str> for KasliPort {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct InvalidKasliPort<'a>(&'a str);
 
-impl<'a> core::fmt::Display for InvalidKasliPort<'a> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl<'a> fmt::Display for InvalidKasliPort<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Invalid Kasli I2C port: {}", self.0)
     }
 }

--- a/artiq/firmware/ddb_parser/src/lib.rs
+++ b/artiq/firmware/ddb_parser/src/lib.rs
@@ -5,8 +5,9 @@ use pyo3::types::{PyDict, PyModule};
 use std::collections::HashMap;
 
 mod devices;
-pub use devices::Device;
+mod i2c;
 
+pub use devices::Device;
 pub type DeviceDb = HashMap<String, Device>;
 
 #[derive(Debug, Error)]

--- a/flake.nix
+++ b/flake.nix
@@ -287,8 +287,15 @@
 
           checkPhase =
             ''
-            cargo test --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml
+            echo 'Check ksupport format'
+            cargo fmt --manifest-path ${self}/artiq/firmware/ksupport/Cargo.toml -- --check
+
+            echo 'Check ddb_parser format'
+            cargo fmt --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml -- --check
+            echo 'Lint ddb_parser'
             cargo clippy --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml  -- -Dwarnings
+            echo 'Test ddb_parser'
+            cargo test --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml
             '';
 
           installPhase =

--- a/flake.nix
+++ b/flake.nix
@@ -262,7 +262,7 @@
       makeKasliSoftwarePackage = { variant }:
         pkgs.stdenv.mkDerivation {
           name = "artiq-software-kasli-${variant}";
-          phases = ["buildPhase" "installPhase"];
+          phases = ["buildPhase" "checkPhase" "installPhase"];
           cargoDeps = firmwareCargoDeps;
 
           nativeBuildInputs = [
@@ -285,6 +285,12 @@
             python -m artiq.gateware.targets.kasli --no-compile-gateware ${self}/${variant}.json
             '';
 
+          checkPhase =
+            ''
+            cargo test --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml
+            cargo clippy --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml  -- -Dwarnings
+            '';
+
           installPhase =
             ''
             mkdir $out
@@ -294,6 +300,7 @@
             fi
             '';
 
+          doCheck = true;
           dontFixup = true;
         };
 


### PR DESCRIPTION
### Summary

Add models to parse Urukul (AD9910) sections of the `device_db` to the `ddb_parser` crate.

### Details

- where easily possible, run formatter, linter, and tests when building the software derivation, such that the tools also run on CI.
- depending on the actual Urukul driver implementation, some data models (e.g. `ddb_parser::i2c::KasliPort`) may move to a `no_std` crate to be usable in the driver implementation as well.
- models for the AD9910 charge pump and VCO selection will be refined later.