### PR TITLE
ksupport: add high-level RTIO timeline syscalls

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -1,5 +1,3 @@
-use board_misoc::csr;
-
 macro_rules! api {
     ($i:ident) => ({
         extern { static $i: u8; }
@@ -147,7 +145,9 @@ static mut API: &'static [(&'static str, *const ())] = &[
     /* proxified syscalls */
     api!(core_log),
     /* RTIO */
-    api!(now = csr::rtio::NOW_HI_ADDR as *const _),
+    api!(now_mu = ::rtio::now_mu),
+    api!(at_mu = ::rtio::at_mu),
+    api!(delay_mu = ::rtio::delay_mu),
     /* RPC */
     api!(rpc_send = ::rpc_send),
     api!(rpc_send_async = ::rpc_send_async),

--- a/artiq/firmware/ksupport/rtio.rs
+++ b/artiq/firmware/ksupport/rtio.rs
@@ -47,6 +47,21 @@ mod imp {
         }
     }
 
+    pub extern "C" fn at_mu(t: i64) {
+        unsafe {
+            csr::rtio::now_hi_write((t >> 32) as u32);
+            csr::rtio::now_lo_write(t as u32);
+        }
+    }
+
+    pub extern "C" fn delay_mu(d: i64) {
+        at_mu(now_mu() + d)
+    }
+
+    pub extern "C" fn now_mu() -> i64 {
+        unsafe { ((csr::rtio::now_hi_read() as i64) << 32) | (csr::rtio::now_lo_read() as i64) }
+    }
+
     // writing the LSB of o_data (offset=0) triggers the RTIO write
     #[inline(always)]
     pub unsafe fn rtio_o_data_write(offset: usize, data: u32) {
@@ -270,6 +285,18 @@ mod imp {
     }
 
     pub extern "C" fn get_counter() -> i64 {
+        unimplemented!("not(has_rtio)")
+    }
+
+    pub extern "C" fn at_mu(t: i64) {
+        unimplemented!("not(has_rtio)")
+    }
+
+    pub extern "C" fn delay_mu(d: i64) {
+        unimplemented!("not(has_rtio)")
+    }
+
+    pub extern "C" fn now_mu() -> i64 {
         unimplemented!("not(has_rtio)")
     }
 


### PR DESCRIPTION
### Summary

Add the high-level RTIO timeline manipulation syscalls:

- `at_mu(t: i64)`: absolute cursor positioning.
- `delay_mu(d: i64)`: relative cursor positioning.
- `now_mu() -> i64`: current cursor position.

The signatures match the [artiq-zynq](https://git.m-labs.hk/M-Labs/artiq-zynq/src/commit/ead20a66a56048a913f7c9751cd377269e615791/src/libksupport/src/rtio_csr.rs#L34-L48) API.

:warning: The raw cursor pointer `now` is not exposed in the kernel API anymore, thus code emitted by the standard ARTIQ compiler for targets with ["now-pinning"](https://github.com/m-labs/artiq/blob/9386a7a16f519655d72d59149a10ad4d06f90066/artiq/compiler/targets.py#L82) (e.g. Kasli2) is not valid anymore if it manipulates the RTIO timeline.

:bulb: Tested on Kasli2 hardware with custom kernels.