### PR TITLE
ksupport: add urukul_init and urukul_count syscalls

### DIFF
--- a/aqt.json
+++ b/aqt.json
@@ -6,14 +6,24 @@
     "hw_rev": "v2.0",
     "base": "standalone",
     "peripherals": [
-	{
-	    "type": "dio",
-	    "board": "DIO_BNC",
-	    "ports": [
-		0
-	    ],
-	    "bank_direction_low": "output",
-	    "bank_direction_high": "output"
-	}
+	        {
+            "type": "dio",
+            "board": "DIO_BNC",
+            "ports": [
+                0
+            ],
+            "edge_counter": true,
+            "bank_direction_low": "input",
+            "bank_direction_high": "output"
+        },
+        {
+            "type": "urukul",
+            "ports": [
+                1,
+		2
+            ],
+	    "synchronization": true,
+	    "clk_sel": 2
+        }
     ]
 }

--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -440,6 +440,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 name = "ksupport"
 version = "0.0.0"
 dependencies = [
+ "bitflags 2.5.0",
  "board_artiq",
  "board_misoc",
  "build_misoc",
@@ -450,6 +451,7 @@ dependencies = [
  "io",
  "itertools",
  "libc 0.1.0",
+ "num_enum",
  "prettyplease",
  "proc-macro2",
  "proto_artiq",
@@ -570,7 +572,6 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.36",
  "syn 2.0.56",
@@ -629,16 +630,6 @@ checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
  "syn 2.0.56",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror",
- "toml",
 ]
 
 [[package]]
@@ -1012,15 +1003,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.36",
  "syn 2.0.56",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/artiq/firmware/ddb_parser/Cargo.toml
+++ b/artiq/firmware/ddb_parser/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 indoc = "2"
-num_enum = "0.7.2"
+num_enum = { version = "0.7.2", default-features = false }
 pyo3 = { version = "0.20", features = ["auto-initialize"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/artiq/firmware/ddb_parser/src/lib.rs
+++ b/artiq/firmware/ddb_parser/src/lib.rs
@@ -4,7 +4,7 @@ use indoc::indoc;
 use pyo3::types::{PyDict, PyModule};
 use std::collections::HashMap;
 
-mod devices;
+pub mod devices;
 mod i2c;
 
 pub use devices::Device;

--- a/artiq/firmware/ksupport/Cargo.toml
+++ b/artiq/firmware/ksupport/Cargo.toml
@@ -30,3 +30,5 @@ proto_artiq = { path = "../libproto_artiq" }
 riscv = { version = "0.6.0", features = ["inline-asm"] }
 libc = { path = "../libc" }
 unwind = { path = "../libunwind" }
+num_enum = { version = "0.7.2", default-features = false }
+bitflags = "2.4"

--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -196,4 +196,7 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(led_count = ::sinara::led_count),
     api!(led_on = ::sinara::led_on),
     api!(led_off = ::sinara::led_off),
+    // Urukul
+    api!(urukul_init = ::sinara::urukul_init),
+    api!(urukul_count = ::sinara::urukul_count),
 ];

--- a/artiq/firmware/ksupport/build.rs
+++ b/artiq/firmware/ksupport/build.rs
@@ -35,7 +35,8 @@ fn main() {
     let ddb_py = fs::read_to_string(&ddb_path).unwrap();
     let ddb = ddb_parser::parse(&ddb_py).unwrap();
 
-    let code = vec![led_code(&ddb), ttl_out_code(&ddb)];
+    let core = find_core(&ddb).expect("Missing core device.");
+    let code = vec![led_code(&ddb), ttl_out_code(&ddb), urukul_code(&ddb, &core)];
 
     let definition_tokens = code.iter().map(|entry| &entry.definition_tokens);
     let instantiation_tokens = code.iter().map(|entry| &entry.instantiation_tokens);
@@ -133,5 +134,182 @@ fn led_code(ddb: &DeviceDb) -> DeviceTypeCode {
         instantiation_tokens: quote! {
             led: [#( ttl::TtlOut { channel: #channels } ),*]
         },
+    }
+}
+
+/// Emit code for the `PERIPHERALS` data for Urukul devices.
+fn urukul_code(ddb: &DeviceDb, core: &ddb_parser::devices::Core) -> DeviceTypeCode {
+    let urukuls: Vec<_> = ddb
+        .iter()
+        .filter_map(|entry| match entry {
+            (key, Device::UrukulCpld { arguments }) => {
+                Some(Urukul::from_ddb(key, arguments, ddb, core))
+            }
+            _ => None,
+        })
+        .sorted_by_key(|entry| entry.spi_channel)
+        .collect();
+
+    let count = urukuls.len();
+    if count > 0 {
+        println!("cargo:rustc-cfg={}", "has_sinara_urukul");
+    }
+
+    let tokens = urukuls.iter().map(|entry| entry.tokens());
+
+    DeviceTypeCode {
+        definition_tokens: quote! {
+            urukul: [urukul::Cpld; #count]
+        },
+        instantiation_tokens: quote! {
+            urukul: [#( #tokens ),*]
+        },
+    }
+}
+
+/// Search a SPI master device by key.
+fn find_spi_device<'a, 'b>(
+    key: &'a str,
+    ddb: &'b DeviceDb,
+) -> Option<&'b ddb_parser::devices::Spi2Master> {
+    for entry in ddb {
+        match entry {
+            (ddb_key, Device::Spi2Master { arguments }) if key == ddb_key => {
+                return Some(arguments);
+            }
+            _ => continue,
+        }
+    }
+
+    None
+}
+
+/// Search the core device in the device DB.
+fn find_core(ddb: &DeviceDb) -> Option<&ddb_parser::devices::Core> {
+    for entry in ddb {
+        if let Device::Core { arguments } = entry.1 {
+            return Some(arguments);
+        }
+    }
+
+    None
+}
+
+/// Helper for Urukul code generation.
+#[derive(Debug)]
+struct Urukul<'a> {
+    /// RTIO channel that controls the SPI master.
+    spi_channel: i32,
+
+    /// Clock selection.
+    clk_sel: u8,
+
+    /// Clock divider.
+    clk_div: u8,
+
+    /// Synchronization clock divider.
+    #[allow(dead_code)]
+    sync_div: u8,
+
+    /// Synchronization source selection.
+    sync_sel: u8,
+
+    /// Core device.
+    core: &'a ddb_parser::devices::Core,
+}
+
+impl<'a> Urukul<'a> {
+    /// Fill a `Urukul` struct from a particular device DB entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - device key
+    /// * `dev` - entry content for `key`
+    /// * `ddb` - the containing device DB
+    /// * `core` - the containing device DB's core device.
+    fn from_ddb(
+        key: &str,
+        dev: &ddb_parser::devices::UrukulCpld,
+        ddb: &DeviceDb,
+        core: &'a ddb_parser::devices::Core,
+    ) -> Self {
+        let (sync_sel, sync_div) = if dev.sync_device.is_some() {
+            (0, dev.sync_div.unwrap_or(2))
+        } else {
+            (1, dev.sync_div.unwrap_or(0))
+        };
+
+        Self {
+            spi_channel: find_spi_device(&dev.spi_device, ddb)
+                .expect(format!("Missing SPI device for Urukul {}", key).as_str())
+                .channel,
+            clk_sel: dev.clk_sel.unwrap_or(0),
+            clk_div: dev.clk_div.unwrap_or(0),
+            sync_div,
+            sync_sel,
+            core,
+        }
+    }
+
+    /// Generated code for the Urukul device.
+    fn tokens(&self) -> TokenStream {
+        let bus_tokens = self.bus_tokens();
+        let config_tokens = self.config_tokens();
+
+        quote! {
+            urukul::Cpld { #bus_tokens, #config_tokens }
+        }
+    }
+
+    /// Generated code for the SPI bus driver.
+    fn bus_tokens(&self) -> TokenStream {
+        let channel = self.spi_channel;
+        let ref_period_mu = self.core.ref_multiplier.unwrap_or(8) as i64;
+
+        #[rustfmt::skip]
+        quote! {
+            bus: spi2::Bus {
+		channel: #channel,
+		ref_period_mu: #ref_period_mu,
+            }
+        }
+    }
+
+    /// Generated code for the CPLD configuration.
+    fn config_tokens(&self) -> TokenStream {
+        // FIXME: use actual type for the conversion
+        let clk_sel = match self.clk_sel {
+            0 => quote! { urukul::ClkSel::Internal },
+            1 => quote! { urukul::ClkSel::Sma },
+            2 => quote! { urukul::ClkSel::Mmcx },
+            _ => panic!("Invalid clk_sel"),
+        };
+
+        let clk_div = match self.clk_div {
+            0 => quote! { urukul::ClkDiv::Default },
+            1 => quote! { urukul::ClkDiv::One },
+            2 => quote! { urukul::ClkDiv::Two },
+            3 => quote! { urukul::ClkDiv::Four },
+            _ => panic!("Invalid clk_div"),
+        };
+
+        let sync_sel = match self.sync_sel {
+            0 => quote! { urukul::SyncSel::Eem },
+            1 => quote! { urukul::SyncSel::Dds0 },
+            _ => panic!("Invalid sync_sel"),
+        };
+
+        #[rustfmt::skip]
+	quote! {
+	    config: urukul::Config {
+		profile: 7,
+		io_update: false,
+		reset: false,
+		io_reset: false,
+		clk_sel: #clk_sel,
+		clk_div: #clk_div,
+		sync_sel: #sync_sel,
+	    }
+	}
     }
 }

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -13,6 +13,12 @@ extern crate io;
 extern crate proto_artiq;
 extern crate riscv;
 
+#[macro_use(bitflags)]
+extern crate bitflags;
+
+#[macro_use(IntoPrimitive, TryFromPrimitive)]
+extern crate num_enum;
+
 use board_artiq::{mailbox, rpc_queue};
 use board_misoc::csr;
 use core::{convert::TryFrom, mem, ptr, slice, str};
@@ -111,6 +117,7 @@ mod eh_artiq;
 mod nrt_bus;
 mod rtio;
 mod sinara;
+mod spi2;
 
 static mut LIBRARY: Option<Library<'static>> = None;
 

--- a/artiq/firmware/ksupport/sinara/mod.rs
+++ b/artiq/firmware/ksupport/sinara/mod.rs
@@ -1,7 +1,11 @@
 #[cfg(not(has_rtio))]
 compile_error!("Need RTIO to use Sinara drivers");
 
-pub mod ttl;
+mod ttl;
+mod urukul;
+
+#[cfg(has_sinara_urukul)]
+use crate::spi2;
 
 include!(concat!(env!("OUT_DIR"), "/peripherals.rs"));
 
@@ -28,4 +32,12 @@ pub extern "C" fn led_off(channel: usize) {
 
 pub extern "C" fn led_count() -> usize {
     PERIPHERALS.led.len()
+}
+
+pub extern "C" fn urukul_init(board: usize) -> bool {
+    PERIPHERALS.urukul[board].init(false).is_ok()
+}
+
+pub extern "C" fn urukul_count() -> usize {
+    PERIPHERALS.urukul.len()
 }

--- a/artiq/firmware/ksupport/sinara/urukul/config.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/config.rs
@@ -1,0 +1,174 @@
+use core::convert::{TryFrom, TryInto};
+
+/// Urukul configuration register.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Config {
+    // TODO: add RF switches and LED configuration.
+    pub profile: u8,
+    pub io_update: bool,
+    // TODO: add mask_nu
+    pub clk_sel: ClkSel,
+    pub sync_sel: SyncSel,
+    pub reset: bool,
+    pub io_reset: bool,
+    pub clk_div: ClkDiv,
+}
+
+/// Input clock divider.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ClkDiv {
+    Default = 0,
+
+    /// Divide by one.
+    One = 1,
+
+    /// Divide by two.
+    Two = 2,
+
+    /// Divide by four.
+    Four = 3,
+}
+
+impl Default for ClkDiv {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl ClkDiv {
+    /// Reference clock divider, as integer.
+    pub fn divider(&self) -> i32 {
+        match self {
+            Self::Default | Self::Four => 4,
+            Self::One => 1,
+            Self::Two => 2,
+        }
+    }
+}
+
+/// Reference clock input selection.
+///
+/// Only supports Urukul v1.3+.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ClkSel {
+    /// On-board crystal, 100 MHz.
+    Internal = 0,
+
+    /// Front-panel SMA connector.
+    Sma = 1,
+
+    /// Internal MMCX connector.
+    Mmcx = 2,
+}
+
+impl Default for ClkSel {
+    fn default() -> Self {
+        Self::Internal
+    }
+}
+
+/// DDS inter-chip synchronization clock source selection.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum SyncSel {
+    /// EEM1 connector, LVDS pair 0.
+    Eem = 0,
+
+    /// On-board DDS chip 0.
+    Dds0 = 1,
+}
+
+impl Default for SyncSel {
+    fn default() -> Self {
+        Self::Dds0
+    }
+}
+
+impl Config {
+    // Field offsets in the configuration register.
+    #[allow(dead_code)]
+    const RF_SW: u8 = 0;
+    #[allow(dead_code)]
+    const LED: u8 = 4;
+    const PROFILE: u8 = 8;
+    const IO_UPDATE: u8 = 12;
+    #[allow(dead_code)]
+    const MASK_NU: u8 = 13;
+    const CLK_SEL0: u8 = 17;
+    const SYNC_SEL: u8 = 18;
+    const RST: u8 = 19;
+    const IO_RST: u8 = 20;
+    const CLK_SEL1: u8 = 21;
+    const CLK_DIV: u8 = 22;
+}
+
+impl TryFrom<i32> for Config {
+    type Error = super::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        let clk_sel0 = (value >> Self::CLK_SEL0) & 1;
+        let clk_sel1 = (value >> Self::CLK_SEL1) & 1;
+        let clk_sel = clk_sel0 | (clk_sel1 << 1);
+
+        let sync_sel = (value >> Self::SYNC_SEL) & 1;
+        let clk_div = (value >> Self::CLK_DIV) & 3;
+
+        Ok(Self {
+            profile: ((value >> Self::PROFILE) & 7) as u8,
+            io_update: ((value >> Self::IO_UPDATE) & 1) != 0,
+            clk_sel: ClkSel::try_from(clk_sel as u8)
+                .map_err(|_| Self::Error::InvalidClkSel(clk_sel))?,
+            sync_sel: SyncSel::try_from(sync_sel as u8)
+                .map_err(|_| Self::Error::InvalidSyncSel(sync_sel))?,
+            reset: ((value >> Self::RST) & 1) != 0,
+            io_reset: ((value >> Self::IO_RST) & 1) != 0,
+            clk_div: ClkDiv::try_from(clk_div as u8)
+                .map_err(|_| Self::Error::InvalidClkDiv(clk_div))?,
+        })
+    }
+}
+
+impl From<Config> for i32 {
+    fn from(config: Config) -> Self {
+        (&config).into()
+    }
+}
+
+impl From<&Config> for i32 {
+    fn from(config: &Config) -> Self {
+        let clk_sel: u8 = config.clk_sel.into();
+        let sync_sel: u8 = config.sync_sel.into();
+        let clk_div: u8 = config.clk_div.into();
+
+        ((config.profile as i32) << Config::PROFILE)
+            | (bool_to_i32(config.io_update) << Config::IO_UPDATE)
+            | (((clk_sel & 1) as i32) << Config::CLK_SEL0)
+            | (((sync_sel & 1) as i32) << Config::SYNC_SEL)
+            | (bool_to_i32(config.reset) << Config::RST)
+            | (bool_to_i32(config.io_reset) << Config::IO_RST)
+            | ((((clk_sel >> 1) & 1) as i32) << Config::CLK_SEL1)
+            | ((clk_div as i32) << Config::CLK_DIV)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            profile: 7,
+            clk_sel: ClkSel::default(),
+            clk_div: ClkDiv::default(),
+            sync_sel: SyncSel::default(),
+            ..0i32.try_into().unwrap()
+        }
+    }
+}
+
+fn bool_to_i32(value: bool) -> i32 {
+    if value {
+        1
+    } else {
+        0
+    }
+}

--- a/artiq/firmware/ksupport/sinara/urukul/cpld.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/cpld.rs
@@ -1,0 +1,108 @@
+use super::{Config, Error, Status};
+use crate::{rtio, spi2};
+
+type Result<T> = core::result::Result<T, Error>;
+
+struct SpiConfig {}
+
+impl SpiConfig {
+    // SPI clock dividers for configuration register read/write.
+    const DIV_CFG_WR: i32 = 2;
+    const DIV_CFG_RD: i32 = 16;
+
+    // TODO: add clock dividers for other targets
+
+    const FLAGS: spi2::Flags = spi2::Flags::CsPolarity;
+}
+
+#[derive(Debug)]
+pub struct Cpld {
+    pub bus: spi2::Bus,
+    pub config: Config,
+}
+
+impl Cpld {
+    /// Initialize board-level components.
+    pub fn init(&self, blind: bool) -> Result<()> {
+        if !blind && !self.read_status_register()?.proto_rev_matches() {
+            return Err(Error::ProtoRevMismatch);
+        }
+
+        rtio::delay_mu(100_000);
+
+        // Pulse IO reset.
+        self.write_configuration_register(Config {
+            io_reset: true,
+            ..self.config
+        })?;
+        rtio::delay_mu(100_000);
+        self.write_configuration_register(Config {
+            io_reset: false,
+            ..self.config
+        })?;
+
+        // TODO: setup sync clock.
+
+        rtio::delay_mu(1_000_000); // DDS wake-up
+        Ok(())
+    }
+
+    /// Read the status register.
+    pub fn read_status_register(&self) -> Result<Status> {
+        let config_reg: i32 = (&self.config).into();
+
+        Ok(self
+            .bus
+            .configure_mu(
+                SpiConfig::FLAGS | spi2::Flags::End | spi2::Flags::Input,
+                24,
+                SpiConfig::DIV_CFG_RD,
+                Cs::Cfg.into(),
+            )?
+            .write(config_reg << 8)
+            .read()
+            .into())
+    }
+
+    /// Write the configuration register.
+    pub fn write_configuration_register(&self, config: Config) -> Result<()> {
+        let config_reg: i32 = config.into();
+
+        self.bus
+            .configure_mu(
+                SpiConfig::FLAGS | spi2::Flags::End,
+                24,
+                SpiConfig::DIV_CFG_WR,
+                Cs::Cfg.into(),
+            )?
+            .write(config_reg << 8);
+
+        Ok(())
+    }
+}
+
+/// SPI target selection.
+#[derive(Debug, Clone, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+enum Cs {
+    /// Configuration register.
+    Cfg = 1,
+
+    /// Coarse attenuators.
+    Att = 2,
+
+    /// Multiple DDS chip, as selected by `mask_nu` in the configuration register.
+    DdsMulti = 3,
+
+    /// DDS chip 0.
+    DdsCh0 = 4,
+
+    /// DDS chip 1.
+    DdsCh1 = 5,
+
+    /// DDS chip 2.
+    DdsCh2 = 6,
+
+    /// DDS chip 3.
+    DdsCh3 = 7,
+}

--- a/artiq/firmware/ksupport/sinara/urukul/mod.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/mod.rs
@@ -1,0 +1,24 @@
+mod config;
+mod cpld;
+mod status;
+
+pub use self::config::{ClkDiv, ClkSel, Config, SyncSel};
+pub use self::cpld::Cpld;
+pub use self::status::{IfcMode, Status};
+
+use crate::spi2;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    Spi(spi2::Error),
+    InvalidClkSel(i32),
+    InvalidSyncSel(i32),
+    InvalidClkDiv(i32),
+    ProtoRevMismatch,
+}
+
+impl From<spi2::Error> for Error {
+    fn from(other: spi2::Error) -> Self {
+        Self::Spi(other)
+    }
+}

--- a/artiq/firmware/ksupport/sinara/urukul/status.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/status.rs
@@ -1,0 +1,49 @@
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Status {
+    // TODO: add rf_switch
+    // TODO: add smp_error
+    // TODO: add pll_lock
+    /// DIP-switch setting.
+    pub ifc_mode: IfcMode,
+
+    /// Protocol revision, 7 bits.
+    pub proto_rev: u8,
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub struct IfcMode: u8 {
+    /// Whether the AD9910 variant is populated.
+    const En9910 = 0x01;
+    /// Whether the NU-Servo (SU-Servo) mode is used.
+    const EnNu = 0x02;
+    /// Whether the SYNC signals on EEM1 must be driven.
+    const EnEem1 = 0x04;
+    }
+}
+
+impl Status {
+    #[allow(dead_code)]
+    const RF_SW: u8 = 0;
+    #[allow(dead_code)]
+    const SMP_ERR: u8 = 4;
+    #[allow(dead_code)]
+    const PLL_LOCK: u8 = 8;
+    const IFC_MODE: u8 = 12;
+    const PROTO_REV: u8 = 16;
+
+    /// True if the protocol revision is supported by this driver.
+    pub fn proto_rev_matches(&self) -> bool {
+        self.proto_rev == 0x08
+    }
+}
+
+impl From<i32> for Status {
+    fn from(value: i32) -> Self {
+        Self {
+            ifc_mode: IfcMode::from_bits_truncate(((value >> Self::IFC_MODE) & 0xf) as u8),
+            proto_rev: ((value >> Self::PROTO_REV) & 0x7f) as u8,
+        }
+    }
+}

--- a/artiq/firmware/ksupport/spi2.rs
+++ b/artiq/firmware/ksupport/spi2.rs
@@ -1,0 +1,106 @@
+use crate::rtio;
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone)]
+    pub struct Flags: u8 {
+    const Offline = 0x01;
+    const End = 0x02;
+    const Input = 0x04;
+    const CsPolarity = 0x08;
+    const ClkPolarity = 0x10;
+    const ClkPhase = 0x20;
+    const LsbFirst = 0x40;
+    const HalfDuplex = 0x80;
+    }
+}
+
+#[derive(Debug)]
+pub struct Bus {
+    pub channel: i32,
+    pub ref_period_mu: i64,
+}
+
+#[derive(Debug)]
+pub struct ConfiguredBus {
+    channel: i32,
+    xfer_duration_mu: i64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    InvalidTransferLength(i32),
+    InvalidClockDivider(i32),
+    DeadlineMissed,
+}
+
+impl Bus {
+    /// Offset of the configuration register in the RTIO PHY, relative to the base RTIO channel.
+    const CONFIG_ADDR: i32 = 1;
+
+    /// Offset of the data register in the RTIO PHY, relative to the base RTIO channel.
+    const DATA_ADDR: i32 = 0;
+
+    /// Configure the RTIO PHY for upcoming transactions.
+    ///
+    /// # Arguments
+    ///
+    /// * `flags` - SPI transaction flags.
+    /// * `length` - SPI transfer length. Must be between 1 and 32 (included).
+    /// * `div` - SPI clock divider. The base clock is the RTIO clock. Must be between 2 and 257 (included).
+    /// * `cs` - SPI chip select.
+    pub fn configure_mu(
+        &self,
+        flags: Flags,
+        length: i32,
+        div: i32,
+        cs: u8,
+    ) -> Result<ConfiguredBus, Error> {
+        if !(1..=32).contains(&length) {
+            return Err(Error::InvalidTransferLength(length));
+        }
+
+        if !(2..=257).contains(&div) {
+            return Err(Error::InvalidClockDivider(div));
+        }
+
+        rtio::output(
+            (self.channel << 8) | Self::CONFIG_ADDR,
+            (flags.bits() as i32) | ((length - 1) << 8) | ((div - 2) << 16) | ((cs as i32) << 24),
+        );
+
+        rtio::delay_mu(self.ref_period_mu);
+
+        Ok(ConfiguredBus {
+            channel: self.channel,
+            xfer_duration_mu: xfer_duration_mu(div, length),
+        })
+    }
+}
+
+impl ConfiguredBus {
+    /// Write to the SPI bus.
+    ///
+    /// The length of the written data is determined by the bus configuration.
+    ///
+    /// The timeline cursor is advanced by the transfer duration.
+    pub fn write(&self, data: i32) -> &Self {
+        rtio::output((self.channel << 8) | Bus::DATA_ADDR, data);
+        rtio::delay_mu(self.xfer_duration_mu);
+        self
+    }
+
+    /// Read from the SPI bus.
+    ///
+    /// The length of the read data is determined by the bus configuration.
+    ///
+    /// This function blocks until data is available.
+    pub fn read(&self) -> i32 {
+        rtio::input_data(self.channel)
+    }
+}
+
+fn xfer_duration_mu(div: i32, length: i32) -> i64 {
+    let ref_multiplier = 8; // TODO: read from device_db
+    ((length as i64) + 1) * ((div as i64) + 1) * ref_multiplier
+}


### PR DESCRIPTION
### Summary

New syscalls:

- `urukul_count`: number of Urukul devices
- `urukul_init`: initialize a single Urukul board *and* all its DDS chip.

:bulb: The `urukul_init` implementation is incomplete. In particular, it doesn't yet perform the synchronization clock and coarse attenuation setup and DDS chips initialization (setup, PLL lock).

### Details

- In this first step, the Urukul syscalls and related driver are not meant to be generic and will have the following limitations:
  - AD9910-only, with limited features.
  - Synchronization clock on EEM only.
  - RF switches controlled by EEM only.

- The code generation needs to convert the settings from `ddb_parser` models to `ksupport::sinara::urukul::config` ones. The logic is currently duplicated, because the original is in the `ksupport` crate and the build script cannot depend on the crate it runs for. A follow-up patch will move those data structures into a separate `no_std` crate, such that they can be shared between `ddb_parser` and `ksupport`.