### PR TITLE
ksupport/spi: read ref_multiplier from device DB

### DIFF
--- a/artiq/firmware/ddb_parser/src/core.rs
+++ b/artiq/firmware/ddb_parser/src/core.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct Core {
+    pub host: String,
+    pub ref_period: f32,
+
+    #[serde(default = "default_ref_multiplier")]
+    pub ref_multiplier: u32,
+
+    #[serde(default)]
+    pub target: Target,
+}
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub enum Target {
+    #[serde(rename = "rv32ima")]
+    Kasli1,
+    #[serde(rename = "rv32g")]
+    Kasli2,
+    #[serde(rename = "cortexa9")]
+    KasliSoc,
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Self::Kasli2
+    }
+}
+
+fn default_ref_multiplier() -> u32 {
+    8
+}

--- a/artiq/firmware/ddb_parser/src/devices.rs
+++ b/artiq/firmware/ddb_parser/src/devices.rs
@@ -1,4 +1,4 @@
-use crate::i2c;
+use crate::{core::Core, i2c};
 use serde::Deserialize;
 use serde_with::{serde_as, TryFromInto};
 
@@ -34,24 +34,6 @@ pub enum Device {
 
     #[serde(untagged)]
     Unknown(Ignored),
-}
-
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-pub struct Core {
-    pub host: String,
-    pub ref_period: f32,
-    pub ref_multiplier: Option<i32>,
-    pub target: Option<Target>,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub enum Target {
-    #[serde(rename = "rv32ima")]
-    Kasli1,
-    #[serde(rename = "rv32g")]
-    Kasli2,
-    #[serde(rename = "cortexa9")]
-    KasliSoc,
 }
 
 #[derive(Debug, Deserialize, Clone, Eq, PartialEq)]

--- a/artiq/firmware/ddb_parser/src/lib.rs
+++ b/artiq/firmware/ddb_parser/src/lib.rs
@@ -4,6 +4,7 @@ use indoc::indoc;
 use pyo3::types::{PyDict, PyModule};
 use std::collections::HashMap;
 
+pub mod core;
 pub mod devices;
 mod i2c;
 

--- a/artiq/firmware/ksupport/spi2.rs
+++ b/artiq/firmware/ksupport/spi2.rs
@@ -73,7 +73,7 @@ impl Bus {
 
         Ok(ConfiguredBus {
             channel: self.channel,
-            xfer_duration_mu: xfer_duration_mu(div, length),
+            xfer_duration_mu: xfer_duration_mu(div, length, self.ref_period_mu),
         })
     }
 }
@@ -100,7 +100,6 @@ impl ConfiguredBus {
     }
 }
 
-fn xfer_duration_mu(div: i32, length: i32) -> i64 {
-    let ref_multiplier = 8; // TODO: read from device_db
+fn xfer_duration_mu(div: i32, length: i32, ref_multiplier: i64) -> i64 {
     ((length as i64) + 1) * ((div as i64) + 1) * ref_multiplier
 }

--- a/artiq/firmware/libbuild_ksupport/src/ddb.rs
+++ b/artiq/firmware/libbuild_ksupport/src/ddb.rs
@@ -24,7 +24,7 @@ pub(crate) fn spi_device<'a, 'b>(
 ///
 /// # Arguments
 /// - `ddb` - device DB to search in.
-pub(crate) fn core(ddb: &DeviceDb) -> Option<&ddb_parser::devices::Core> {
+pub(crate) fn core(ddb: &DeviceDb) -> Option<&ddb_parser::core::Core> {
     for entry in ddb {
         if let Device::Core { arguments } = entry.1 {
             return Some(arguments);

--- a/artiq/firmware/libbuild_ksupport/src/urukul.rs
+++ b/artiq/firmware/libbuild_ksupport/src/urukul.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
 
-pub(crate) fn emit_code(ddb: &DeviceDb, core: &ddb_parser::devices::Core) -> DeviceTypeCode {
+pub(crate) fn emit_code(ddb: &DeviceDb, core: &ddb_parser::core::Core) -> DeviceTypeCode {
     let urukuls: Vec<_> = ddb
         .iter()
         .filter_map(|entry| match entry {
@@ -51,7 +51,7 @@ struct Urukul<'a> {
     sync_div: u8,
 
     /// Core device.
-    core: &'a ddb_parser::devices::Core,
+    core: &'a ddb_parser::core::Core,
 }
 
 impl<'a> Urukul<'a> {
@@ -67,7 +67,7 @@ impl<'a> Urukul<'a> {
         key: &str,
         dev: &ddb_parser::devices::UrukulCpld,
         ddb: &DeviceDb,
-        core: &'a ddb_parser::devices::Core,
+        core: &'a ddb_parser::core::Core,
     ) -> Self {
         let (sync_sel, sync_div) = if dev.sync_device.is_some() {
             (
@@ -109,7 +109,7 @@ impl<'a> Urukul<'a> {
 
     fn bus_tokens(&self) -> TokenStream {
         let channel = self.spi_channel;
-        let ref_period_mu = self.core.ref_multiplier.unwrap_or(8) as i64;
+        let ref_period_mu = self.core.ref_multiplier as i64;
 
         #[rustfmt::skip]
 	quote! {


### PR DESCRIPTION
### Summary

In the `spi2` driver, read the [`ref_multiplier`](https://github.com/m-labs/artiq/blob/9386a7a16f519655d72d59149a10ad4d06f90066/artiq/coredevice/core.py#L78-L80) used for calculating the transfer duration (in machine units) from the device DB (instead of hard-coding it).