### PR TITLE
ddb_parser: add most default values

### DIFF
--- a/artiq/firmware/ddb_parser/src/devices.rs
+++ b/artiq/firmware/ddb_parser/src/devices.rs
@@ -1,6 +1,5 @@
-use crate::{core::Core, i2c};
+use crate::{core::Core, eeprom, i2c, phaser, spi2, ttl, urukul};
 use serde::Deserialize;
-use serde_with::{serde_as, TryFromInto};
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(tag = "_qualclass")]
@@ -12,167 +11,37 @@ pub enum Device {
     #[serde(rename = "artiq.coredevice.dma.CoreDMA")]
     CoreDma {},
     #[serde(rename = "artiq.coredevice.i2c.I2CSwitch")]
-    I2cSwitch { arguments: I2cSwitch },
+    I2cSwitch { arguments: i2c::Switch },
     #[serde(rename = "artiq.coredevice.ttl.TTLOut")]
-    TtlOut { arguments: TtlOut },
+    TtlOut { arguments: ttl::TtlOut },
     #[serde(rename = "artiq.coredevice.ttl.TTLInOut")]
-    TtlInOut { arguments: TtlInOut },
+    TtlInOut { arguments: ttl::TtlInOut },
     #[serde(rename = "artiq.coredevice.ttl.TTLClockGen")]
-    TtlClockGen { arguments: TtlClockGen },
+    TtlClockGen { arguments: ttl::TtlClockGen },
     #[serde(rename = "artiq.coredevice.edge_counter.EdgeCounter")]
-    EdgeCounter { arguments: EdgeCounter },
+    EdgeCounter { arguments: ttl::EdgeCounter },
     #[serde(rename = "artiq.coredevice.urukul.CPLD")]
-    UrukulCpld { arguments: UrukulCpld },
+    UrukulCpld { arguments: urukul::Cpld },
     #[serde(rename = "artiq.coredevice.ad9910.AD9910")]
-    Ad9910 { arguments: Ad9910 },
+    Ad9910 { arguments: urukul::Ad9910 },
     #[serde(rename = "artiq.coredevice.phaser.Phaser")]
-    Phaser { arguments: Phaser },
+    Phaser { arguments: phaser::Phaser },
     #[serde(rename = "artiq.coredevice.spi2.SPIMaster")]
-    Spi2Master { arguments: Spi2Master },
+    Spi2Master { arguments: spi2::Master },
     #[serde(rename = "artiq.coredevice.kasli_i2c.KasliEEPROM")]
-    KasliEeprom { arguments: KasliEeprom },
+    KasliEeprom { arguments: eeprom::Kasli },
 
     #[serde(untagged)]
     Unknown(Ignored),
 }
 
 #[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct I2cSwitch {
-    pub busno: Option<i32>,
-    pub address: Option<u8>,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct TtlOut {
-    pub channel: i32,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct TtlInOut {
-    pub channel: i32,
-    pub gate_latency_mu: Option<i32>,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct TtlClockGen {
-    pub channel: i32,
-    pub acc_width: Option<i32>,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct EdgeCounter {
-    pub channel: i32,
-    pub gateware_width: Option<i32>,
-}
-
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-pub struct UrukulCpld {
-    pub spi_device: String,
-    pub io_update_device: Option<String>,
-    pub dds_reset_device: Option<String>,
-    pub sync_device: Option<String>,
-    pub sync_sel: Option<sinara_config::urukul::SyncSel>,
-    pub clk_sel: Option<sinara_config::urukul::ClkSel>,
-    pub clk_div: Option<sinara_config::urukul::ClkDiv>,
-    pub rf_sw: Option<u8>,
-    pub refclk: Option<f64>,
-    pub att: Option<u32>,
-    pub sync_div: Option<u8>,
-}
-
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-pub struct Ad9910 {
-    pub cpld_device: String,
-    pub chip_select: i32,
-    pub sw_device: Option<String>,
-    pub pll_n: Option<i32>,
-    pub pll_cp: Option<i32>,  // TODO: use ad9910-pac type
-    pub pll_vco: Option<i32>, // TODO: use ad9910-pac type
-    pub sync_delay_seed: Option<MaybeOnEeprom>,
-    pub io_update_delay: Option<MaybeOnEeprom>,
-    #[serde(default)]
-    #[serde(deserialize_with = "optional_bool_from_int")]
-    pub pll_en: Option<bool>,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
-#[serde(untagged)]
-pub enum MaybeOnEeprom {
-    EepromAddress(EepromAddress),
-    Value(u32),
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-#[serde(try_from = "String")]
-pub struct EepromAddress {
-    pub eeprom_device: String,
-    pub offset: u32,
-}
-
-impl TryFrom<String> for EepromAddress {
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        let parts: Vec<_> = value.split(':').collect();
-        if parts.len() != 2 {
-            return Err("Invalid EepromAddress format.".into());
-        }
-
-        Ok(Self {
-            eeprom_device: parts[0].into(),
-            offset: parts[1]
-                .parse::<_>()
-                .map_err(|e| format!("Invalid offset: {}", e))?,
-        })
-    }
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct Phaser {
-    pub channel_base: i32,
-    pub miso_delay: Option<i32>,
-    pub tune_fifo_offset: Option<bool>,
-    pub clk_sel: Option<u8>,
-    pub sync_dly: Option<i32>,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct Spi2Master {
-    pub channel: i32,
-    pub div: Option<i32>,
-    pub length: Option<i32>,
-}
-
-#[serde_as]
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct KasliEeprom {
-    #[serde_as(as = "TryFromInto<&str>")]
-    pub port: i2c::KasliPort,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct Ignored {}
-
-/// Deserialize optional booleans from integers.
-/// https://github.com/serde-rs/serde/issues/1344#issuecomment-410309140
-fn optional_bool_from_int<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    match Option::<u8>::deserialize(deserializer)? {
-        None => Ok(None),
-        Some(0) => Ok(Some(false)),
-        Some(1) => Ok(Some(true)),
-        Some(other) => Err(serde::de::Error::invalid_value(
-            serde::de::Unexpected::Unsigned(other as u64),
-            &"zero or one",
-        )),
-    }
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eeprom::{EepromAddress, MaybeOnEeprom};
 
     #[test]
     fn test_parse_urukul_typical() {
@@ -194,12 +63,12 @@ mod tests {
 
         match dev {
             Device::UrukulCpld { arguments } => {
-                assert_eq!(arguments.clk_sel, Some(sinara_config::urukul::ClkSel::Mmcx));
+                assert_eq!(arguments.clk_sel, sinara_config::urukul::ClkSel::Mmcx);
+                assert_eq!(arguments.clk_div, sinara_config::urukul::ClkDiv::Default);
                 assert_eq!(
-                    arguments.clk_div,
-                    Some(sinara_config::urukul::ClkDiv::Default)
+                    arguments.sync_sel,
+                    sinara_config::urukul::SyncSel::default()
                 );
-                assert!(arguments.sync_sel.is_none());
             }
             _ => panic!("Must be Urukul CPLD"),
         }
@@ -226,23 +95,23 @@ mod tests {
 
         match dev {
             Device::Ad9910 { arguments } => {
-                assert!(arguments.pll_en.unwrap());
-                assert_eq!(arguments.pll_n.unwrap(), 32);
+                assert!(arguments.pll_en);
+                assert_eq!(arguments.pll_n, 32);
                 assert_eq!(arguments.chip_select, 4);
                 assert_eq!(arguments.cpld_device, "urukul0_cpld");
                 assert_eq!(
                     arguments.sync_delay_seed,
-                    Some(MaybeOnEeprom::EepromAddress(EepromAddress {
+                    MaybeOnEeprom::EepromAddress(EepromAddress {
                         eeprom_device: "eeprom_urukul0".into(),
                         offset: 64,
-                    }))
+                    })
                 );
                 assert_eq!(
                     arguments.io_update_delay,
-                    Some(MaybeOnEeprom::EepromAddress(EepromAddress {
+                    MaybeOnEeprom::EepromAddress(EepromAddress {
                         eeprom_device: "eeprom_urukul0".into(),
                         offset: 68,
-                    }))
+                    })
                 );
             }
             _ => panic!("Must be Ad9910"),
@@ -265,7 +134,7 @@ mod tests {
 
         match dev {
             Device::Ad9910 { arguments } => {
-                assert!(arguments.pll_en.is_none());
+                assert!(arguments.pll_en);
             }
             _ => panic!("Must be Ad9910."),
         }
@@ -288,7 +157,7 @@ mod tests {
 
         match dev {
             Device::Ad9910 { arguments } => {
-                assert_eq!(arguments.pll_en, Some(false));
+                assert!(!arguments.pll_en);
             }
             _ => panic!("Must be Ad9910."),
         }
@@ -311,7 +180,7 @@ mod tests {
 
         match dev {
             Device::Ad9910 { arguments } => {
-                assert_eq!(arguments.sync_delay_seed, Some(MaybeOnEeprom::Value(32)));
+                assert_eq!(arguments.sync_delay_seed, MaybeOnEeprom::Value(32));
             }
             _ => panic!("Must be Ad9910."),
         }
@@ -332,7 +201,7 @@ mod tests {
 
         match dev {
             Device::KasliEeprom { arguments } => {
-                assert_eq!(arguments.port, i2c::KasliPort::Eem3)
+                assert_eq!(arguments.port, sinara_config::i2c::KasliPort::Eem3)
             }
             _ => panic!("Must be KasliEEPROM."),
         }

--- a/artiq/firmware/ddb_parser/src/eeprom.rs
+++ b/artiq/firmware/ddb_parser/src/eeprom.rs
@@ -1,0 +1,68 @@
+use serde::Deserialize;
+use serde_with::{serde_as, TryFromInto};
+use std::fmt;
+
+#[serde_as]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct Kasli {
+    #[serde_as(as = "TryFromInto<&str>")]
+    pub port: sinara_config::i2c::KasliPort,
+}
+
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum MaybeOnEeprom {
+    EepromAddress(EepromAddress),
+    Value(u32),
+}
+
+impl Default for MaybeOnEeprom {
+    fn default() -> Self {
+        Self::Value(0)
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+#[serde(try_from = "&str")]
+pub struct EepromAddress {
+    pub eeprom_device: String,
+    pub offset: u32,
+}
+
+impl TryFrom<&str> for EepromAddress {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let mut parts = value.split(':');
+
+        let eeprom_device = parts
+            .next()
+            .ok_or_else(|| Self::Error::InvalidDesignator(value.into()))?
+            .into();
+        let offset = parts
+            .next()
+            .ok_or_else(|| Self::Error::InvalidDesignator(value.into()))?
+            .parse::<_>()
+            .map_err(|_| Self::Error::InvalidOffset)?;
+
+        Ok(Self {
+            eeprom_device,
+            offset,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    InvalidDesignator(String),
+    InvalidOffset,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDesignator(value) => write!(f, "Invalid EEPROM designator: {}", value),
+            Self::InvalidOffset => write!(f, "Invalid EEPROM offset"),
+        }
+    }
+}

--- a/artiq/firmware/ddb_parser/src/i2c.rs
+++ b/artiq/firmware/ddb_parser/src/i2c.rs
@@ -1,58 +1,18 @@
-use num_enum::{IntoPrimitive, TryFromPrimitive};
-use std::fmt;
+use serde::Deserialize;
 
-#[derive(Debug, Eq, PartialEq, Clone, IntoPrimitive, TryFromPrimitive)]
-#[repr(u8)]
-pub enum KasliPort {
-    Eem0 = 7,
-    Eem1 = 5,
-    Eem2 = 4,
-    Eem3 = 3,
-    Eem4 = 2,
-    Eem5 = 1,
-    Eem6 = 0,
-    Eem7 = 6,
-    Eem8 = 12,
-    Eem9 = 13,
-    Eem10 = 15,
-    Eem11 = 14,
-    Sfp0 = 8,
-    Sfp1 = 9,
-    Sfp2 = 10,
-    Loc0 = 11,
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct Switch {
+    #[serde(default = "default_busno")]
+    pub busno: i32,
+
+    #[serde(default = "default_address")]
+    pub address: u8,
 }
 
-impl<'a> TryFrom<&'a str> for KasliPort {
-    type Error = InvalidKasliPort<'a>;
-
-    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
-        match s {
-            "EEM0" => Ok(Self::Eem0),
-            "EEM1" => Ok(Self::Eem1),
-            "EEM2" => Ok(Self::Eem2),
-            "EEM3" => Ok(Self::Eem3),
-            "EEM4" => Ok(Self::Eem4),
-            "EEM5" => Ok(Self::Eem5),
-            "EEM6" => Ok(Self::Eem6),
-            "EEM7" => Ok(Self::Eem7),
-            "EEM8" => Ok(Self::Eem8),
-            "EEM9" => Ok(Self::Eem9),
-            "EEM10" => Ok(Self::Eem10),
-            "EEM11" => Ok(Self::Eem11),
-            "SFP0" => Ok(Self::Sfp0),
-            "SFP1" => Ok(Self::Sfp1),
-            "SFP2" => Ok(Self::Sfp2),
-            "LOC0" => Ok(Self::Loc0),
-            _ => Err(InvalidKasliPort(s)),
-        }
-    }
+fn default_busno() -> i32 {
+    0
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct InvalidKasliPort<'a>(&'a str);
-
-impl<'a> fmt::Display for InvalidKasliPort<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Invalid Kasli I2C port: {}", self.0)
-    }
+fn default_address() -> u8 {
+    0xe8
 }

--- a/artiq/firmware/ddb_parser/src/lib.rs
+++ b/artiq/firmware/ddb_parser/src/lib.rs
@@ -5,8 +5,13 @@ use pyo3::types::{PyDict, PyModule};
 use std::collections::HashMap;
 
 pub mod core;
-pub mod devices;
-mod i2c;
+mod devices;
+pub mod eeprom;
+pub mod i2c;
+pub mod phaser;
+pub mod spi2;
+pub mod ttl;
+pub mod urukul;
 
 pub use devices::Device;
 pub type DeviceDb = HashMap<String, Device>;

--- a/artiq/firmware/ddb_parser/src/phaser.rs
+++ b/artiq/firmware/ddb_parser/src/phaser.rs
@@ -1,0 +1,22 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct Phaser {
+    pub channel_base: i32,
+    #[serde(default = "default_miso_delay")]
+    pub miso_delay: i32,
+    #[serde(default = "default_tune_fifo_offset")]
+    pub tune_fifo_offset: bool,
+    #[serde(default)]
+    pub clk_sel: sinara_config::phaser::ClkSel,
+    #[serde(default)]
+    pub sync_dly: i32,
+}
+
+fn default_miso_delay() -> i32 {
+    1
+}
+
+fn default_tune_fifo_offset() -> bool {
+    true
+}

--- a/artiq/firmware/ddb_parser/src/spi2.rs
+++ b/artiq/firmware/ddb_parser/src/spi2.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct Master {
+    pub channel: i32,
+    #[serde(default)]
+    pub div: i32,
+    #[serde(default)]
+    pub length: i32,
+}

--- a/artiq/firmware/ddb_parser/src/ttl.rs
+++ b/artiq/firmware/ddb_parser/src/ttl.rs
@@ -1,0 +1,36 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct TtlOut {
+    pub channel: i32,
+}
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct TtlInOut {
+    pub channel: i32,
+    pub gate_latency_mu: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct TtlClockGen {
+    pub channel: i32,
+
+    #[serde(default = "default_clk_gen_acc_width")]
+    pub acc_width: i32,
+}
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct EdgeCounter {
+    pub channel: i32,
+
+    #[serde(default = "default_edge_counter_gateware_width")]
+    pub gateware_width: i32,
+}
+
+fn default_clk_gen_acc_width() -> i32 {
+    24
+}
+
+fn default_edge_counter_gateware_width() -> i32 {
+    31
+}

--- a/artiq/firmware/ddb_parser/src/urukul.rs
+++ b/artiq/firmware/ddb_parser/src/urukul.rs
@@ -1,0 +1,69 @@
+use crate::eeprom::MaybeOnEeprom;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct Cpld {
+    pub spi_device: String,
+    pub io_update_device: Option<String>,
+    pub dds_reset_device: Option<String>,
+    pub sync_device: Option<String>,
+    #[serde(default)]
+    pub sync_sel: sinara_config::urukul::SyncSel,
+    #[serde(default)]
+    pub clk_sel: sinara_config::urukul::ClkSel,
+    #[serde(default)]
+    pub clk_div: sinara_config::urukul::ClkDiv,
+    #[serde(default)]
+    pub rf_sw: u8,
+    #[serde(default = "default_refclk")]
+    pub refclk: f64,
+    #[serde(default)]
+    pub att: u32,
+    pub sync_div: Option<u8>,
+}
+
+fn default_refclk() -> f64 {
+    125e6
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct Ad9910 {
+    pub cpld_device: String,
+    pub chip_select: i32,
+    pub sw_device: Option<String>,
+    #[serde(default = "default_pll_n")]
+    pub pll_n: i32,
+    pub pll_cp: Option<i32>,  // TODO: use ad9910-pac type
+    pub pll_vco: Option<i32>, // TODO: use ad9910-pac type
+    #[serde(default)]
+    pub sync_delay_seed: MaybeOnEeprom,
+    #[serde(default)]
+    pub io_update_delay: MaybeOnEeprom,
+    #[serde(default = "default_pll_en")]
+    #[serde(deserialize_with = "bool_from_int")]
+    pub pll_en: bool,
+}
+
+fn default_pll_n() -> i32 {
+    40
+}
+
+fn default_pll_en() -> bool {
+    true
+}
+
+/// Deserialize booleans from integers.
+/// https://github.com/serde-rs/serde/issues/1344#issuecomment-410309140
+fn bool_from_int<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    match u8::deserialize(deserializer)? {
+        0 => Ok(false),
+        1 => Ok(true),
+        other => Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(other as u64),
+            &"zero or one",
+        )),
+    }
+}

--- a/artiq/firmware/libbuild_ksupport/src/ddb.rs
+++ b/artiq/firmware/libbuild_ksupport/src/ddb.rs
@@ -8,7 +8,7 @@ use ddb_parser::{Device, DeviceDb};
 pub(crate) fn spi_device<'a, 'b>(
     key: &'a str,
     ddb: &'b DeviceDb,
-) -> Option<&'b ddb_parser::devices::Spi2Master> {
+) -> Option<&'b ddb_parser::spi2::Master> {
     for entry in ddb {
         match entry {
             (ddb_key, Device::Spi2Master { arguments }) if key == ddb_key => {

--- a/artiq/firmware/libbuild_ksupport/src/urukul.rs
+++ b/artiq/firmware/libbuild_ksupport/src/urukul.rs
@@ -65,7 +65,7 @@ impl<'a> Urukul<'a> {
     /// - `core` - the containing device DB's core device.
     fn from_ddb(
         key: &str,
-        dev: &ddb_parser::devices::UrukulCpld,
+        dev: &ddb_parser::urukul::Cpld,
         ddb: &DeviceDb,
         core: &'a ddb_parser::core::Core,
     ) -> Self {
@@ -86,8 +86,8 @@ impl<'a> Urukul<'a> {
 
         Self {
             spi_channel: spi_device.channel,
-            clk_sel: ClkSel(dev.clk_sel.unwrap_or_default()),
-            clk_div: ClkDiv(dev.clk_div.unwrap_or_default()),
+            clk_sel: ClkSel(dev.clk_sel),
+            clk_div: ClkDiv(dev.clk_div),
             sync_div,
             sync_sel: SyncSel(sync_sel),
             core,

--- a/artiq/firmware/libsinara_config/Cargo.toml
+++ b/artiq/firmware/libsinara_config/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 
 [dependencies]
 num_enum = { version = "0.7.2", default-features = false }
-serde = { version = "1", default-features = false }
+serde = { version = "1", features = ["derive"], default-features = false }
 serde_repr = "0.1"

--- a/artiq/firmware/libsinara_config/src/i2c.rs
+++ b/artiq/firmware/libsinara_config/src/i2c.rs
@@ -1,0 +1,58 @@
+use core::fmt;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+#[derive(Debug, Eq, PartialEq, Clone, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum KasliPort {
+    Eem0 = 7,
+    Eem1 = 5,
+    Eem2 = 4,
+    Eem3 = 3,
+    Eem4 = 2,
+    Eem5 = 1,
+    Eem6 = 0,
+    Eem7 = 6,
+    Eem8 = 12,
+    Eem9 = 13,
+    Eem10 = 15,
+    Eem11 = 14,
+    Sfp0 = 8,
+    Sfp1 = 9,
+    Sfp2 = 10,
+    Loc0 = 11,
+}
+
+impl<'a> TryFrom<&'a str> for KasliPort {
+    type Error = InvalidKasliPort<'a>;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        match s {
+            "EEM0" => Ok(Self::Eem0),
+            "EEM1" => Ok(Self::Eem1),
+            "EEM2" => Ok(Self::Eem2),
+            "EEM3" => Ok(Self::Eem3),
+            "EEM4" => Ok(Self::Eem4),
+            "EEM5" => Ok(Self::Eem5),
+            "EEM6" => Ok(Self::Eem6),
+            "EEM7" => Ok(Self::Eem7),
+            "EEM8" => Ok(Self::Eem8),
+            "EEM9" => Ok(Self::Eem9),
+            "EEM10" => Ok(Self::Eem10),
+            "EEM11" => Ok(Self::Eem11),
+            "SFP0" => Ok(Self::Sfp0),
+            "SFP1" => Ok(Self::Sfp1),
+            "SFP2" => Ok(Self::Sfp2),
+            "LOC0" => Ok(Self::Loc0),
+            _ => Err(InvalidKasliPort(s)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct InvalidKasliPort<'a>(&'a str);
+
+impl<'a> fmt::Display for InvalidKasliPort<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Invalid Kasli I2C port: {}", self.0)
+    }
+}

--- a/artiq/firmware/libsinara_config/src/lib.rs
+++ b/artiq/firmware/libsinara_config/src/lib.rs
@@ -1,3 +1,5 @@
 #![no_std]
 
+pub mod i2c;
+pub mod phaser;
 pub mod urukul;

--- a/artiq/firmware/libsinara_config/src/phaser.rs
+++ b/artiq/firmware/libsinara_config/src/phaser.rs
@@ -1,0 +1,15 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use serde_repr::Deserialize_repr;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, IntoPrimitive, TryFromPrimitive, Deserialize_repr)]
+#[repr(u8)]
+pub enum ClkSel {
+    Mmcx = 0,
+    Sma = 1,
+}
+
+impl Default for ClkSel {
+    fn default() -> Self {
+        Self::Mmcx
+    }
+}


### PR DESCRIPTION
### Summary

Follow-up to #11: add most default values (as defined in the Python drivers) to the `ddb_parser` models. This centralizes the default-value logic and simplifies the code in `build_ksupport`.

The `ddb_parser` crate code is split into files/modules for increased readability.

### Details

Some defaults are not set because:

- the default value depends on other values in the device DB (for example `TtlInOut::gate_latency_mu`). Such cases will be handled later if relevant.
- the field type is not proper yet (for example `Ad9910::pll_cp`). The defaults for these fields will be added once the proper types are available.

The `MaybeOnEeprom` enum cannot move to the `sinara_config` as-is because its deserialization relies on `#[serde(untagged)]`, which is [not supported](https://serde.rs/no-std.html#derive) in when `serde` has `no_std` support. Another type will be necessary when implementing the `Ad9910` driver.