### PR TITLE
ksupport/urukul: setup sync clock generator on initialization

### DIFF
--- a/artiq/firmware/ksupport/sinara/ttl.rs
+++ b/artiq/firmware/ksupport/sinara/ttl.rs
@@ -1,8 +1,16 @@
 use crate::rtio;
 
 #[cfg_attr(not(any(has_sinara_ttl_out, has_sinara_led)), allow(dead_code))]
+#[derive(Debug)]
 pub struct TtlOut {
     pub channel: i32,
+}
+
+#[cfg_attr(not(has_sinara_ttl_clk_gen), allow(dead_code))]
+#[derive(Debug)]
+pub struct TtlClockGen {
+    pub channel: i32,
+    pub acc_width: i64,
 }
 
 #[cfg_attr(not(any(has_sinara_ttl_out, has_sinara_led)), allow(dead_code))]
@@ -20,5 +28,16 @@ impl TtlOut {
 
     fn set_o(&self, o: bool) {
         rtio::output(self.channel << 8, if o { 1 } else { 0 })
+    }
+}
+
+#[cfg_attr(not(has_sinara_ttl_clk_gen), allow(dead_code))]
+impl TtlClockGen {
+    pub fn set_mu(&self, ftw: i32) {
+        rtio::output(self.channel, ftw)
+    }
+
+    pub fn stop(&self) {
+        self.set_mu(0)
     }
 }

--- a/artiq/firmware/ksupport/sinara/urukul/mod.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/mod.rs
@@ -1,3 +1,4 @@
+use super::ttl;
 use crate::spi2;
 use sinara_config::urukul::InvalidConfig;
 
@@ -22,4 +23,14 @@ impl From<InvalidConfig> for Error {
     fn from(other: InvalidConfig) -> Self {
         Self::Config(other)
     }
+}
+
+/// Synchronization generator, when using the EEM variant.
+#[derive(Debug)]
+pub struct SyncGen {
+    /// Clock generator.
+    pub device: ttl::TtlClockGen,
+
+    /// Synchronization clock divider.
+    pub div: u8,
 }

--- a/artiq/firmware/libbuild_ksupport/src/ddb.rs
+++ b/artiq/firmware/libbuild_ksupport/src/ddb.rs
@@ -33,3 +33,24 @@ pub(crate) fn core(ddb: &DeviceDb) -> Option<&ddb_parser::core::Core> {
 
     None
 }
+
+/// First matching TtlClockGen (if any).
+///
+/// # Arguments
+/// - `key` - target device key.
+/// - `ddb` - device DB to search in.
+pub(crate) fn ttl_clock_gen<'a, 'b>(
+    key: &'a str,
+    ddb: &'b DeviceDb,
+) -> Option<&'b ddb_parser::ttl::TtlClockGen> {
+    for entry in ddb {
+        match entry {
+            (ddb_key, Device::TtlClockGen { arguments }) if key == ddb_key => {
+                return Some(arguments)
+            }
+            _ => continue,
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
### Summary

Setup the synchronization clock generator on Urukul initialization. The synchronization clock generator is only enabled if the synchronization clock is provided by the coredevice through the EEM connector. The synchronization clock source and the parameters of the generator (if used) are derived from the device DB.

### Details

- The `TtlClockGen` device driver is added to `ksupport`.
- Device DB searching utilities in `build_ksupport::ddb` could be moved to associated functions of `ddb_parser::DeviceDb`, potentially with a generic implementation.