### PR TITLE
ksupport: add urukul coarse attenuation syscalls

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -199,4 +199,6 @@ static mut API: &'static [(&'static str, *const ())] = &[
     // Urukul
     api!(urukul_init = ::sinara::urukul_init),
     api!(urukul_count = ::sinara::urukul_count),
+    api!(urukul_write_coarse_attenuation = ::sinara::urukul_write_coarse_attenuation),
+    api!(urukul_read_coarse_attenuation = ::sinara::urukul_read_coarse_attenuation),
 ];

--- a/artiq/firmware/ksupport/sinara/mod.rs
+++ b/artiq/firmware/ksupport/sinara/mod.rs
@@ -41,3 +41,20 @@ pub extern "C" fn urukul_init(board: usize) -> bool {
 pub extern "C" fn urukul_count() -> usize {
     PERIPHERALS.urukul.len()
 }
+
+pub extern "C" fn urukul_write_coarse_attenuation(board: usize, att_mu: u32) -> bool {
+    PERIPHERALS.urukul[board]
+        .write_attenuation_register(att_mu)
+        .is_ok()
+}
+
+pub extern "C" fn urukul_read_coarse_attenuation(board: usize, att_mu: *mut u32) -> bool {
+    if let Ok(att) = PERIPHERALS.urukul[board].read_attenuation_register() {
+        unsafe {
+            *att_mu = att;
+        }
+        true
+    } else {
+        false
+    }
+}


### PR DESCRIPTION
### Summary

New syscalls:

- `urukul_write_coarse_attenuation`: write the coarse attenuation setting for all channels on a given Urukul board.
- `urukul_read_coarse_attenuation`: read the coarse attenuation setting for all channels on a given Urukul board.

Tested on hardware.

### Details

The coarse attenuation setting is implemented as a shift register. Therefore, exposing single-channel read/write syscalls doesn't provide any speed optimization. If this is a relevant abstraction, the kernels can implement this on top of the syscalls added in this patch.