### PR TITLE
ksupport: add urukul channel RF switches syscalls

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -201,4 +201,6 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(urukul_count = ::sinara::urukul_count),
     api!(urukul_write_coarse_attenuation = ::sinara::urukul_write_coarse_attenuation),
     api!(urukul_read_coarse_attenuation = ::sinara::urukul_read_coarse_attenuation),
+    api!(urukul_channel_rf_on = ::sinara::urukul_channel_rf_on),
+    api!(urukul_channel_rf_off = ::sinara::urukul_channel_rf_off),
 ];

--- a/artiq/firmware/ksupport/sinara/mod.rs
+++ b/artiq/firmware/ksupport/sinara/mod.rs
@@ -1,3 +1,5 @@
+use core::convert::TryInto;
+
 #[cfg(not(has_rtio))]
 compile_error!("Need RTIO to use Sinara drivers");
 
@@ -57,4 +59,18 @@ pub extern "C" fn urukul_read_coarse_attenuation(board: usize, att_mu: *mut u32)
     } else {
         false
     }
+}
+
+pub extern "C" fn urukul_channel_rf_on(channel: usize) {
+    let (board, channel) = (channel / 4, channel % 4);
+    PERIPHERALS.urukul[board]
+        .channel(channel.try_into().unwrap())
+        .switch_on()
+}
+
+pub extern "C" fn urukul_channel_rf_off(channel: usize) {
+    let (board, channel) = (channel / 4, channel % 4);
+    PERIPHERALS.urukul[board]
+        .channel(channel.try_into().unwrap())
+        .switch_off()
 }

--- a/artiq/firmware/ksupport/sinara/urukul/ad9910.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/ad9910.rs
@@ -1,0 +1,23 @@
+use super::Cpld;
+use crate::sinara::ttl;
+
+/// Urukul AD9910 channel.
+pub struct Ad9910<'a> {
+    /// Urukul board controller.
+    pub cpld: &'a Cpld,
+
+    /// EEM switch line driver.
+    pub switch_device: &'a ttl::TtlOut,
+}
+
+impl Ad9910<'_> {
+    /// Enable the RF output (close the switch).
+    pub fn switch_on(&self) {
+        self.switch_device.on()
+    }
+
+    /// Disable the RF output (open the switch).
+    pub fn switch_off(&self) {
+        self.switch_device.off()
+    }
+}

--- a/artiq/firmware/ksupport/sinara/urukul/mod.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/mod.rs
@@ -1,10 +1,13 @@
+use core::convert::{TryFrom, TryInto};
+
 use super::ttl;
 use crate::spi2;
 use sinara_config::urukul::InvalidConfig;
 
+mod ad9910;
 mod cpld;
 
-pub use self::cpld::Cpld;
+pub use self::cpld::{ChannelDesc, Cpld};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Error {
@@ -33,4 +36,72 @@ pub struct SyncGen {
 
     /// Synchronization clock divider.
     pub div: u8,
+}
+
+/// SPI bus configuration.
+pub(crate) struct SpiConfig {}
+
+impl SpiConfig {
+    // SPI clock dividers for configuration register read/write.
+    const DIV_CFG_WR: i32 = 2;
+    const DIV_CFG_RD: i32 = 16;
+
+    // SPI clock dividers for coarse attenuation read/write.
+    const DIV_ATT_WR: i32 = 6;
+    const DIV_ATT_RD: i32 = 16;
+
+    // TODO: add clock dividers for other targets
+
+    const FLAGS: spi2::Flags = spi2::Flags::CsPolarity;
+}
+
+/// SPI target selection.
+#[derive(Debug, Clone, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub(crate) enum Cs {
+    /// Configuration register.
+    Cfg = 1,
+
+    /// Coarse attenuators.
+    Att = 2,
+
+    /// Multiple DDS chip, as selected by `mask_nu` in the configuration register.
+    DdsMulti = 3,
+
+    /// DDS chip 0.
+    DdsCh0 = 4,
+
+    /// DDS chip 1.
+    DdsCh1 = 5,
+
+    /// DDS chip 2.
+    DdsCh2 = 6,
+
+    /// DDS chip 3.
+    DdsCh3 = 7,
+}
+
+/// Urukul board channel.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum Channel {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+}
+
+impl From<Channel> for usize {
+    fn from(channel: Channel) -> Self {
+        let index: u8 = channel.into();
+        index.into()
+    }
+}
+
+impl TryFrom<usize> for Channel {
+    type Error = <Channel as TryFrom<u8>>::Error;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        (value as u8).try_into()
+    }
 }


### PR DESCRIPTION
### Summary

New syscalls:

- `urukul_channel_rf_on`: enable the RF output on a given Urukul channel (close the on-board RF switch for that channel)
- `urukul_channel_rf_off`: disable the RF output a given Urukul channel (open the on-board RF switch for that channel).

:warning: The dedicated TTL line (on Urukul EEM1) is the only switch actuation mechanism supported. There is a build-time failure if the device DB describes Urukul boards where EEM1 is not connected.

### Details

- the Urukul channels are described by single integers, usually from left to right, top to bottom on a standard crate build. The Urukul boards are ordered by SPI channel number, and the channels on a given board by chip select.

- like for the other indexed operations, the syscalls panic if given an invalid channel index.