### PR TITLE
ksupport: add edge counters syscalls

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -199,6 +199,13 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(led_count = ::sinara::led_count),
     api!(led_on = ::sinara::led_on),
     api!(led_off = ::sinara::led_off),
+    // Edge counter
+    api!(edge_counter_start_gate_rising = ::sinara::edge_counter_start_gate_rising),
+    api!(edge_counter_start_gate_falling = ::sinara::edge_counter_start_gate_falling),
+    api!(edge_counter_start_gate_both = ::sinara::edge_counter_start_gate_both),
+    api!(edge_counter_stop_gate = ::sinara::edge_counter_stop_gate),
+    api!(edge_counter_fetch_count = ::sinara::edge_counter_fetch_count),
+    api!(edge_counter_count = ::sinara::edge_counter_count),
     // Urukul
     api!(urukul_init = ::sinara::urukul_init),
     api!(urukul_count = ::sinara::urukul_count),

--- a/artiq/firmware/ksupport/sinara/edge_counter.rs
+++ b/artiq/firmware/ksupport/sinara/edge_counter.rs
@@ -1,0 +1,56 @@
+use crate::rtio;
+use sinara_config::edge_counter::Config;
+
+#[cfg_attr(not(has_sinara_edge_counter), allow(dead_code))]
+#[derive(Debug)]
+pub struct EdgeCounter {
+    pub channel: i32,
+    pub gateware_width: i32,
+}
+
+#[cfg_attr(not(has_sinara_edge_counter), allow(dead_code))]
+impl EdgeCounter {
+    /// Close the counter gate.
+    pub fn stop_gate(&self) {
+        self.set_config(Config::SendCountEvent);
+    }
+
+    /// Open the counter gate, count rising edges.
+    pub fn start_gate_rising(&self) {
+        self.set_config(Config::CountRising | Config::ResetToZero);
+    }
+
+    /// Open the counter gate, count falling edges.
+    pub fn start_gate_falling(&self) {
+        self.set_config(Config::CountFalling | Config::ResetToZero);
+    }
+
+    /// Open the counter gate, count both rising and falling edges.
+    pub fn start_gate_both(&self) {
+        self.set_config(Config::CountRising | Config::CountFalling | Config::ResetToZero);
+    }
+
+    /// Wait for and return count total from previously requested input event.
+    ///
+    /// If is valid to trigger multiple gate periods without immediately
+    /// reading back the count total. The results will be returned in
+    /// order on subsequent fetch calls.
+    ///
+    /// This function blocks until a result becomes available.
+    ///
+    /// Returns -1 if the counter overflowed.
+    pub fn fetch_count(&self) -> i32 {
+        let counter_max = (1 << (self.gateware_width - 1)) - 1;
+
+        let count = rtio::input_data(self.channel);
+        if count == counter_max {
+            -1
+        } else {
+            count
+        }
+    }
+
+    fn set_config(&self, config: Config) {
+        rtio::output(self.channel << 8, config.bits());
+    }
+}

--- a/artiq/firmware/ksupport/sinara/mod.rs
+++ b/artiq/firmware/ksupport/sinara/mod.rs
@@ -3,6 +3,7 @@ use core::convert::TryInto;
 #[cfg(not(has_rtio))]
 compile_error!("Need RTIO to use Sinara drivers");
 
+mod edge_counter;
 mod ttl;
 mod urukul;
 
@@ -36,6 +37,30 @@ pub extern "C" fn led_off(channel: usize) {
 
 pub extern "C" fn led_count() -> usize {
     PERIPHERALS.led.len()
+}
+
+pub extern "C" fn edge_counter_start_gate_rising(channel: usize) {
+    PERIPHERALS.edge_counter[channel].start_gate_rising()
+}
+
+pub extern "C" fn edge_counter_start_gate_falling(channel: usize) {
+    PERIPHERALS.edge_counter[channel].start_gate_falling()
+}
+
+pub extern "C" fn edge_counter_start_gate_both(channel: usize) {
+    PERIPHERALS.edge_counter[channel].start_gate_both()
+}
+
+pub extern "C" fn edge_counter_stop_gate(channel: usize) {
+    PERIPHERALS.edge_counter[channel].stop_gate()
+}
+
+pub extern "C" fn edge_counter_fetch_count(channel: usize) -> i32 {
+    PERIPHERALS.edge_counter[channel].fetch_count()
+}
+
+pub extern "C" fn edge_counter_count() -> usize {
+    PERIPHERALS.edge_counter.len()
 }
 
 pub extern "C" fn urukul_count() -> usize {

--- a/artiq/firmware/libbuild_ksupport/src/edge_counter.rs
+++ b/artiq/firmware/libbuild_ksupport/src/edge_counter.rs
@@ -1,0 +1,35 @@
+use crate::DeviceTypeCode;
+use ddb_parser::{Device, DeviceDb};
+use itertools::Itertools;
+use quote::quote;
+
+pub(crate) fn emit_code(ddb: &DeviceDb) -> DeviceTypeCode {
+    let args: Vec<_> = ddb
+        .iter()
+        .filter_map(|entry| match entry.1 {
+            Device::EdgeCounter { arguments } => Some(arguments),
+            _ => None,
+        })
+        .sorted_by_key(|args| args.channel)
+        .collect();
+
+    let count = args.len();
+    if count > 0 {
+        println!("cargo:rustc-cfg=has_sinara_edge_counter");
+    }
+
+    let channels = args.iter().map(|entry| entry.channel);
+    let gateware_widths = args.iter().map(|entry| entry.gateware_width);
+
+    DeviceTypeCode {
+        definition_tokens: quote! {
+            edge_counter:  [edge_counter::EdgeCounter; #count],
+        },
+        instantiation_tokens: quote! {
+            edge_counter: [#(edge_counter::EdgeCounter {
+            channel: #channels,
+            gateware_width: #gateware_widths,
+            }),*],
+        },
+    }
+}

--- a/artiq/firmware/libbuild_ksupport/src/lib.rs
+++ b/artiq/firmware/libbuild_ksupport/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 mod ddb;
+mod edge_counter;
 mod led;
 mod ttl;
 mod urukul;
@@ -25,6 +26,7 @@ pub fn generate_peripherals_code() {
     let code = vec![
         led::emit_code(&ddb),
         ttl::emit_code(&ddb),
+        edge_counter::emit_code(&ddb),
         urukul::emit_code(&ddb, core),
     ];
 

--- a/artiq/firmware/libsinara_config/src/edge_counter.rs
+++ b/artiq/firmware/libsinara_config/src/edge_counter.rs
@@ -1,0 +1,12 @@
+use bitflags::bitflags;
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub struct Config: i32 {
+    const CountRising = 1;
+    const CountFalling = 2;
+    const SendCountEvent = 4;
+    const ResetToZero = 8;
+    }
+}

--- a/artiq/firmware/libsinara_config/src/lib.rs
+++ b/artiq/firmware/libsinara_config/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod edge_counter;
 pub mod i2c;
 pub mod phaser;
 pub mod urukul;


### PR DESCRIPTION
### Summary

New syscalls:

- `edge_counter_start_gate_rising`: open a counter's gate, count rising edges
- `edge_counter_start_gate_falling`: open a counter's gate, count falling edges
- `edge_counter_start_gate_both`: open a counter's gate, count both rising and falling edges
-  `edge_counter_stop_gate`: close a counter's gate, emit the associated RTIO input even.
- `edge_counter_fetch_count`: retrieve counts from a previous gate open period.
- `edge_counter_count`: number of edge counter channels.

Reference implementation: https://github.com/m-labs/artiq/blob/e627aaeda0216efc1f78973d457fb61fd310ce62/artiq/coredevice/edge_counter.py