### PR TITLE
ksupport: add result_store_i32 syscall

### DIFF
--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "num_enum",
  "proto_artiq",
  "riscv",
+ "rpc-data",
  "sinara_config",
  "unwind",
 ]
@@ -791,6 +792,10 @@ dependencies = [
  "lazy_static",
  "regex",
 ]
+
+[[package]]
+name = "rpc-data"
+version = "0.1.0"
 
 [[package]]
 name = "runtime"

--- a/artiq/firmware/ksupport/Cargo.toml
+++ b/artiq/firmware/ksupport/Cargo.toml
@@ -28,3 +28,4 @@ num_enum = { version = "0.7.2", default-features = false }
 bitflags = "2.4"
 sinara_config = { path = "../libsinara_config" }
 ad9910-pac = { path = "../ad9910-pac" }
+rpc-data = { path = "../librpc_data" }

--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -211,4 +211,6 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(urukul_channel_rf_off = ::sinara::urukul_channel_rf_off),
     api!(urukul_channel_set_mu = ::sinara::urukul_channel_set_mu),
     api!(urukul_channel_set_mu_coherent = ::sinara::urukul_channel_set_mu_coherent),
+    // Result
+    api!(result_store_i32 = ::rpc::store_result_i32),
 ];

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -13,6 +13,7 @@ extern crate eh;
 extern crate io;
 extern crate proto_artiq;
 extern crate riscv;
+extern crate rpc_data;
 extern crate sinara_config;
 
 #[macro_use(bitflags)]
@@ -117,6 +118,7 @@ macro_rules! raise {
 mod api;
 mod eh_artiq;
 mod nrt_bus;
+mod rpc;
 mod rtio;
 mod sinara;
 mod spi2;

--- a/artiq/firmware/ksupport/rpc.rs
+++ b/artiq/firmware/ksupport/rpc.rs
@@ -1,0 +1,25 @@
+use crate::rpc_send_async;
+use cslice::AsCSlice;
+use rpc_data::service_id;
+
+/// Store a i32 result on the host.
+///
+/// This function emits an async RPC call to the host.
+///
+/// # Arguments
+///
+/// * `identifier` - identifier for this result.
+/// * `result` - result value to store.
+pub fn store_result_i32(identifier: i32, result: i32) {
+    let tag = &(b"ii:n")[..];
+    let args = [
+        &identifier as *const i32 as *const (),
+        &result as *const i32 as *const (),
+    ];
+
+    rpc_send_async(
+        service_id::STORE_RESULT_I32,
+        &tag.as_c_slice(),
+        args.as_ptr(),
+    );
+}

--- a/artiq/firmware/librpc_data/Cargo.toml
+++ b/artiq/firmware/librpc_data/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rpc-data"
+description = "Shared RPC data."
+authors = ["Alpine Quantum Technologies GmbH <info@aqt.eu>"]
+license = "MIT"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/artiq/firmware/librpc_data/src/lib.rs
+++ b/artiq/firmware/librpc_data/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+/// Known RPC service IDs.
+pub mod service_id {
+    /// Store a i32 result on the host.
+    /// async fn(identifier: i32, result: i32)
+    pub const STORE_RESULT_I32: u32 = 0x100;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -297,6 +297,8 @@
             cargo fmt --manifest-path ${self}/artiq/firmware/libsinara_config/Cargo.toml -- --check
             echo 'Check ad9910-pac format'
             cargo fmt --manifest-path ${self}/artiq/firmware/ad9910-pac/Cargo.toml -- --check
+            echo 'Check rpc-data format'
+            cargo fmt --manifest-path ${self}/artiq/firmware/librpc_data/Cargo.toml -- --check
 
             echo 'Lint ddb_parser'
             cargo clippy --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml  -- -Dwarnings
@@ -306,6 +308,8 @@
             cargo clippy --target-dir ./cargo --manifest-path ${self}/artiq/firmware/libsinara_config/Cargo.toml -- -Dwarnings
             echo 'Lint ad9910-pac'
             cargo clippy --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ad9910-pac/Cargo.toml -- -Dwarnings
+            echo 'Lint rpc-data'
+            cargo clippy --target-dir ./cargo --manifest-path ${self}/artiq/firmware/librpc_data/Cargo.toml -- -Dwarnings
 
             echo 'Test ddb_parser'
             cargo test --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ddb_parser/Cargo.toml
@@ -313,6 +317,8 @@
             cargo test --target-dir ./cargo --manifest-path ${self}/artiq/firmware/libsinara_config/Cargo.toml
             echo 'Test ad9910-pac'
             cargo test --target-dir ./cargo --manifest-path ${self}/artiq/firmware/ad9910-pac/Cargo.toml
+            echo 'Test rpc-data'
+            cargo test --target-dir ./cargo --manifest-path ${self}/artiq/firmware/librpc_data/Cargo.toml
             '';
 
           installPhase =


### PR DESCRIPTION
### Summary

New syscall:

- `result_store_i32`: store a `i32` result, identified by a `i32` label.

The results are propagated to the host via an async RPC call. The RPC service ID is defined in the new `rpc-data` crate, to be easily shared with host code handling the call.