### PR TITLE
ksupport: DMA support for new device drivers

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -201,8 +201,6 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(led_off = ::sinara::led_off),
     // Edge counter
     api!(edge_counter_start_gate_rising = ::sinara::edge_counter_start_gate_rising),
-    api!(edge_counter_start_gate_falling = ::sinara::edge_counter_start_gate_falling),
-    api!(edge_counter_start_gate_both = ::sinara::edge_counter_start_gate_both),
     api!(edge_counter_stop_gate = ::sinara::edge_counter_stop_gate),
     api!(edge_counter_fetch_count = ::sinara::edge_counter_fetch_count),
     api!(edge_counter_count = ::sinara::edge_counter_count),

--- a/artiq/firmware/ksupport/sinara/edge_counter.rs
+++ b/artiq/firmware/ksupport/sinara/edge_counter.rs
@@ -11,23 +11,15 @@ pub struct EdgeCounter {
 #[cfg_attr(not(has_sinara_edge_counter), allow(dead_code))]
 impl EdgeCounter {
     /// Close the counter gate.
+    #[inline]
     pub fn stop_gate(&self) {
         self.set_config(Config::SendCountEvent);
     }
 
     /// Open the counter gate, count rising edges.
+    #[inline]
     pub fn start_gate_rising(&self) {
         self.set_config(Config::CountRising | Config::ResetToZero);
-    }
-
-    /// Open the counter gate, count falling edges.
-    pub fn start_gate_falling(&self) {
-        self.set_config(Config::CountFalling | Config::ResetToZero);
-    }
-
-    /// Open the counter gate, count both rising and falling edges.
-    pub fn start_gate_both(&self) {
-        self.set_config(Config::CountRising | Config::CountFalling | Config::ResetToZero);
     }
 
     /// Wait for and return count total from previously requested input event.
@@ -39,6 +31,7 @@ impl EdgeCounter {
     /// This function blocks until a result becomes available.
     ///
     /// Returns -1 if the counter overflowed.
+    #[inline]
     pub fn fetch_count(&self) -> i32 {
         let counter_max = (1 << (self.gateware_width - 1)) - 1;
 
@@ -50,6 +43,7 @@ impl EdgeCounter {
         }
     }
 
+    #[inline(always)]
     fn set_config(&self, config: Config) {
         unsafe { crate::RTIO_OUTPUT_FN(self.channel << 8, config.bits()) }
     }

--- a/artiq/firmware/ksupport/sinara/edge_counter.rs
+++ b/artiq/firmware/ksupport/sinara/edge_counter.rs
@@ -51,6 +51,6 @@ impl EdgeCounter {
     }
 
     fn set_config(&self, config: Config) {
-        rtio::output(self.channel << 8, config.bits());
+        unsafe { crate::RTIO_OUTPUT_FN(self.channel << 8, config.bits()) }
     }
 }

--- a/artiq/firmware/ksupport/sinara/mod.rs
+++ b/artiq/firmware/ksupport/sinara/mod.rs
@@ -43,14 +43,6 @@ pub extern "C" fn edge_counter_start_gate_rising(channel: usize) {
     PERIPHERALS.edge_counter[channel].start_gate_rising()
 }
 
-pub extern "C" fn edge_counter_start_gate_falling(channel: usize) {
-    PERIPHERALS.edge_counter[channel].start_gate_falling()
-}
-
-pub extern "C" fn edge_counter_start_gate_both(channel: usize) {
-    PERIPHERALS.edge_counter[channel].start_gate_both()
-}
-
 pub extern "C" fn edge_counter_stop_gate(channel: usize) {
     PERIPHERALS.edge_counter[channel].stop_gate()
 }

--- a/artiq/firmware/ksupport/sinara/ttl.rs
+++ b/artiq/firmware/ksupport/sinara/ttl.rs
@@ -33,14 +33,14 @@ impl TtlOut {
     }
 
     fn set_o(&self, o: bool) {
-        rtio::output(self.channel << 8, if o { 1 } else { 0 })
+        unsafe { crate::RTIO_OUTPUT_FN(self.channel << 8, if o { 1 } else { 0 }) }
     }
 }
 
 #[cfg_attr(not(has_sinara_ttl_clk_gen), allow(dead_code))]
 impl TtlClockGen {
     pub fn set_mu(&self, ftw: i32) {
-        rtio::output(self.channel << 8, ftw)
+        unsafe { crate::RTIO_OUTPUT_FN(self.channel << 8, ftw) }
     }
 
     pub fn stop(&self) {

--- a/artiq/firmware/ksupport/sinara/ttl.rs
+++ b/artiq/firmware/ksupport/sinara/ttl.rs
@@ -18,20 +18,24 @@ impl TtlOut {
     #[allow(dead_code)]
     pub fn output(&self) {}
 
+    #[inline]
     pub fn on(&self) {
         self.set_o(true)
     }
 
+    #[inline]
     pub fn off(&self) {
         self.set_o(false)
     }
 
+    #[inline]
     pub fn pulse_mu(&self, duration: i64) {
         self.on();
         rtio::delay_mu(duration);
         self.off();
     }
 
+    #[inline(always)]
     fn set_o(&self, o: bool) {
         unsafe { crate::RTIO_OUTPUT_FN(self.channel << 8, if o { 1 } else { 0 }) }
     }
@@ -39,11 +43,8 @@ impl TtlOut {
 
 #[cfg_attr(not(has_sinara_ttl_clk_gen), allow(dead_code))]
 impl TtlClockGen {
+    #[inline(always)]
     pub fn set_mu(&self, ftw: i32) {
         unsafe { crate::RTIO_OUTPUT_FN(self.channel << 8, ftw) }
-    }
-
-    pub fn stop(&self) {
-        self.set_mu(0)
     }
 }

--- a/artiq/firmware/ksupport/sinara/urukul/ad9910.rs
+++ b/artiq/firmware/ksupport/sinara/urukul/ad9910.rs
@@ -107,11 +107,13 @@ impl Ad9910<'_> {
     }
 
     /// Enable the RF output (close the switch).
+    #[inline(always)]
     pub fn switch_on(&self) {
         self.config.switch_device.on()
     }
 
     /// Disable the RF output (open the switch).
+    #[inline(always)]
     pub fn switch_off(&self) {
         self.config.switch_device.off()
     }

--- a/artiq/firmware/ksupport/spi2.rs
+++ b/artiq/firmware/ksupport/spi2.rs
@@ -63,10 +63,15 @@ impl Bus {
             return Err(Error::InvalidClockDivider(div));
         }
 
-        rtio::output(
-            (self.channel << 8) | Self::CONFIG_ADDR,
-            (flags.bits() as i32) | ((length - 1) << 8) | ((div - 2) << 16) | ((cs as i32) << 24),
-        );
+        unsafe {
+            crate::RTIO_OUTPUT_FN(
+                (self.channel << 8) | Self::CONFIG_ADDR,
+                (flags.bits() as i32)
+                    | ((length - 1) << 8)
+                    | ((div - 2) << 16)
+                    | ((cs as i32) << 24),
+            );
+        }
 
         rtio::delay_mu(self.ref_period_mu);
 
@@ -84,7 +89,7 @@ impl ConfiguredBus {
     ///
     /// The timeline cursor is advanced by the transfer duration.
     pub fn write(&self, data: i32) -> &Self {
-        rtio::output((self.channel << 8) | Bus::DATA_ADDR, data);
+        unsafe { crate::RTIO_OUTPUT_FN((self.channel << 8) | Bus::DATA_ADDR, data) };
         rtio::delay_mu(self.xfer_duration_mu);
         self
     }


### PR DESCRIPTION
Implement DMA recording for drivers in kernel support code. Instead of rebinding the `rtio_output` and `rtio_output_wide` symbols in the user library, mutate the target of function pointers within the kernel support code. This is fine because the code is single-threaded and works like for the `DMA_RECORDER` global.

Removed syscalls (unused):
- `edge_counter_start_gate_falling`
- `edge_counter_start_gate_both`