### PR TITLE
prod: add mock_input_data syscall

### DIFF
--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -14,6 +14,18 @@ name = "alloc_list"
 version = "0.0.0"
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.7",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +181,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+dependencies = [
+ "as-slice",
+ "generic-array 0.14.7",
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "io"
 version = "0.0.0"
 dependencies = [
@@ -187,6 +248,7 @@ dependencies = [
  "cslice",
  "dyld",
  "eh",
+ "heapless",
  "io",
  "libc 0.1.0",
  "proto_artiq",
@@ -375,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,3 +499,9 @@ dependencies = [
  "libc 0.1.0",
  "unwind",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/artiq/firmware/ksupport/Cargo.toml
+++ b/artiq/firmware/ksupport/Cargo.toml
@@ -23,3 +23,4 @@ proto_artiq = { path = "../libproto_artiq" }
 riscv = { version = "0.6.0", features = ["inline-asm"] }
 libc = { path = "../libc" }
 unwind = { path = "../libunwind" }
+heapless = "0.6.1"

--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -148,7 +148,8 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(rtio_output = ::rtio::output),
     api!(rtio_output_wide = ::rtio::output_wide),
     api!(rtio_input_timestamp = ::rtio::input_timestamp),
-    api!(rtio_input_data = ::rtio::input_data),
+    api!(mock_input_data = ::mock_input_data),
+    api!(rtio_input_data = ::rtio_input_data),
     api!(rtio_input_timestamped_data = ::rtio::input_timestamped_data),
 
     api!(dma_record_start = ::dma_record_start),


### PR DESCRIPTION
Add the code for RTIO input events mocking to the AQT production code.