### PR TITLE
ksupport: add clear_mock_input_data to kernel API, increase mock data size

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -148,6 +148,7 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(rtio_output = ::rtio::output),
     api!(rtio_output_wide = ::rtio::output_wide),
     api!(rtio_input_timestamp = ::rtio::input_timestamp),
+    api!(clear_mock_input_data = ::clear_mock_input_data),
     api!(mock_input_data = ::mock_input_data),
     api!(rtio_input_data = ::rtio_input_data),
     api!(rtio_input_timestamped_data = ::rtio::input_timestamped_data),

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -230,7 +230,7 @@ extern fn cache_put(key: &CSlice<u8>, list: &CSlice<i32>) {
 #[derive(Debug)]
 struct InputDataMock {
     channel: i32,
-    data: heapless::Vec<i32, heapless::consts::U128>,
+    data: heapless::Vec<i32, heapless::consts::U256>,
     current: usize,
     consume_events: bool,
 }


### PR DESCRIPTION
Follow-up to #29, where I forgot to add the new syscall `clear_mock_input_data` to the kernel API.

Fly-by: increase the mock data length (per channel) from 128 to 256 samples.