### PR TITLE
artiq_compile: allow RPCs, optionally print RPC info, fix status code on error

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -9,7 +9,6 @@ import os, re, linecache, inspect, textwrap, types as pytypes, numpy, json
 from typing import Any, Callable, Optional
 from dataclasses import dataclass
 from collections import OrderedDict, defaultdict
-from unittest.mock import MagicMock
 
 from pythonparser import ast, algorithm, source, diagnostic, parse_buffer
 from pythonparser import lexer as source_lexer, parser as source_parser

--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -5,18 +5,24 @@ the references to the host objects and translates the functions
 annotated as ``@kernel`` when they are referenced.
 """
 
-import os, re, linecache, inspect, textwrap, types as pytypes, numpy
+import os, re, linecache, inspect, textwrap, types as pytypes, numpy, json
+from typing import Any, Callable, Optional
+from dataclasses import dataclass
 from collections import OrderedDict, defaultdict
+from unittest.mock import MagicMock
 
 from pythonparser import ast, algorithm, source, diagnostic, parse_buffer
 from pythonparser import lexer as source_lexer, parser as source_parser
 
 from Levenshtein import ratio as similarity, jaro_winkler
 
+from typing_extensions import Self
+
 from ..language import core as language_core
 from . import types, builtins, asttyped, math_fns, prelude
 from .transforms import ASTTypedRewriter, Inferencer, IntMonomorphizer, TypedtreePrinter
 from .transforms.asttyped_rewriter import LocalExtractor
+from .ir import rpc_tag
 
 
 class SpecializedFunction:
@@ -37,6 +43,99 @@ class SpecializedFunction:
 
     def __hash__(self):
         return hash((self.instance_type, self.host_function))
+
+@dataclass
+class RpcInfo:
+    """Information on a RPC."""
+
+    service_id: int
+    """Identifier of the service."""
+
+    code: Callable[..., Any]
+    """The called function, as Python function."""
+
+    arg_types: list[str]
+    """Argument types, as RPC tags."""
+
+    return_type: str
+    """Return type, as RPC tag."""
+
+    is_async: bool
+    """Whether the call is asynchronous."""
+
+    is_portable: bool
+    """Whether the implementation is portable (host and coredevice)."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "service_id": self.service_id,
+            "name": self.code.__name__,
+            "is_async": self.is_async,
+            "is_portable": self.is_portable,
+            "args": self.arg_types,
+            "return": self.return_type,
+        }
+
+    @classmethod
+    def new(cls, *, service_id: int, code: Callable[..., Any]) -> Self:
+        """Derive detailed information from the data in the embedding map."""
+        sig = inspect.signature(code)
+
+        embedding_info = getattr(
+            code,
+            "artiq_embedded",
+            language_core._ARTIQEmbeddedInfo(
+                core_name=None,
+                portable=False,
+                function=None,
+                syscall=None,
+                forbidden=False,
+                flags=set()
+            )
+        )
+
+        is_async = "async" in embedding_info.flags
+
+        if sig.return_annotation is inspect._empty:
+            return_type = None
+        else:
+            return_type = sig.return_annotation
+
+        if is_async and return_type is not None:
+            msg = f"Async RPC ({service_id=}) has non-None return type {return_type}."
+            raise ValueError(msg)
+
+        def _rpc_tag(name, ty) -> str:
+            if name == "self":
+                return "O"
+
+            if ty is None:
+                return "n"
+            
+            if ty is inspect._empty:
+                # FIXME: this is more restrictive than the compiler
+                # accepts because there's no type inference.
+                msg = f"Missing annotation for parameter {name} in RPC {code.__name__}"
+                raise ValueError(msg)
+
+            tag = rpc_tag(ty, lambda _: None)
+
+            if tag is None:
+                msg = f"Failed to determine tag for parameter {name} in RPC {code.__name__}"
+                raise ValueError(msg)
+
+            return tag.decode()
+
+        arg_types = [_rpc_tag(name, p.annotation) for name, p in sig.parameters.items()]
+
+        return cls(
+            service_id,
+            code,
+            arg_types=arg_types,
+            return_type=_rpc_tag("return", return_type),
+            is_async=is_async,
+            is_portable=embedding_info.portable
+        )
 
 
 class EmbeddingMap:
@@ -178,6 +277,14 @@ class EmbeddingMap:
     def has_rpc(self):
         return any(filter(lambda x: inspect.isfunction(x) or inspect.ismethod(x),
                           self.object_forward_map.values()))
+
+    def rpc_info(self) -> list[RpcInfo]:
+        """List RPCs."""
+        return [
+            RpcInfo.new(service_id=service_id, code=fn)
+            for service_id, fn in self.object_forward_map.items()
+            if inspect.isfunction(fn) or inspect.ismethod(fn)
+        ]
 
 
 class ASTSynthesizer:

--- a/artiq/frontend/artiq_compile.py
+++ b/artiq/frontend/artiq_compile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, sys, logging, argparse
+import os, sys, logging, argparse, json
 
 from sipyco import common_args
 
@@ -26,6 +26,10 @@ def get_argparser():
                         help="device database file (default: '%(default)s')")
     parser.add_argument("--dataset-db", default="dataset_db.pyon",
                         help="dataset file (default: '%(default)s')")
+    parser.add_argument("--allow-rpcs", default=False, action="store_true",
+                        help="produce a kernel library even if the compiled class contains RPCs")
+    parser.add_argument("--rpc-info", default=None,
+                        help="RPC information output (as JSON)")
 
     parser.add_argument("-c", "--class-name", default=None,
                         help="name of the class to compile")
@@ -67,8 +71,15 @@ def main():
     finally:
         device_mgr.close_devices()
 
-    if object_map.has_rpc():
+    if not args.allow_rpcs and object_map.has_rpc():
         raise ValueError("Experiment must not use RPC")
+
+    if args.rpc_info is not None:
+        info = [
+            rpc.to_dict() for rpc in object_map.rpc_info()
+        ]
+        with (sys.stdout if args.rpc_info == "-" else open(args.rpc_info, "w")) as fp:
+            print(json.dumps({"rpcs": info}, indent=4), file=fp, flush=True)
 
     output = args.output
     if output is None:

--- a/artiq/frontend/artiq_compile.py
+++ b/artiq/frontend/artiq_compile.py
@@ -66,8 +66,9 @@ def main():
         object_map, kernel_library, _, _ = \
             core.compile(exp.run, [exp_inst], {},
                          attribute_writeback=False, print_as_rpc=False)
-    except CompileError as error:
-        return
+    except CompileError:
+        # Error is already printed.
+        sys.exit(1)
     finally:
         device_mgr.close_devices()
 


### PR DESCRIPTION
Make `artiq_compile` exit with status 1 on compilation errors.

Add two options to `artiq_compile`:

* `--allow-rpcs`: if passed, the compilation doesn't fail and produces a kernel library even if the compiled class contains RPCs. Such a kernel library cannot in principle be executed by `artiq_run`, because the RPC endpoints may be missing. This is useful e.g. when compiling for verification-only purposes.
* `--rpc-info`: if passed, dump a JSON object that summarizes the RPCs used, including their service ID and type signature.

For example, if the following RPCs are used:

```python
@rpc(flags={"async"})
def async_rpc(a: TList(TInt32)):
    print(a)

def sync_rpc(a: TInt32) -> TInt32:
    return a + 3
```

then the RPC info is (up to `service_id`s):

```json
{
    "rpcs": [
        {
            "service_id": 1,
            "name": "async_rpc",
            "is_async": true,
            "is_portable": false,
            "args": [
                "li"
            ],
            "return": "n"
        },
        {
            "service_id": 2,
            "name": "sync_rpc",
            "is_async": false,
            "is_portable": false,
            "args": [
                "i"
            ],
            "return": "i"
        }
    ]
}
```