### PR TITLE
targets/kasli: make the number of Grabber ROI engines configurable

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -463,6 +463,13 @@
                             },
                             "minItems": 1,
                             "maxItems": 3
+                        },
+                        "roi_engine_count": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 32,
+                            "default": 16,
+                            "description": "Number of ROI engines."
                         }
                     },
                     "required": ["ports"]

--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -497,12 +497,12 @@ class Grabber(_EEM):
 
     @classmethod
     def add_std(cls, target, eem, eem_aux=None, eem_aux2=None, ttl_out_cls=None,
-            iostandard=default_iostandard):
+            iostandard=default_iostandard, roi_engine_count=16):
         cls.add_extension(target, eem, eem_aux, iostandard=iostandard)
 
         pads = target.platform.request("grabber{}_video".format(eem))
         target.platform.add_period_constraint(pads.clk_p, 14.71)
-        phy = grabber.Grabber(pads)
+        phy = grabber.Grabber(pads, roi_engine_count=roi_engine_count)
         name = "grabber{}".format(len(target.grabber_csr_group))
         setattr(target.submodules, name, phy)
 

--- a/artiq/gateware/eem_7series.py
+++ b/artiq/gateware/eem_7series.py
@@ -103,7 +103,15 @@ def peripheral_grabber(module, peripheral, **kwargs):
         port, port_aux, port_aux2 = peripheral["ports"]
     else:
         raise ValueError("wrong number of ports")
-    eem.Grabber.add_std(module, port, port_aux, port_aux2, **kwargs)
+
+    eem.Grabber.add_std(
+        module,
+        port,
+        port_aux,
+        port_aux2,
+        roi_engine_count=peripheral["roi_engine_count"],
+        **kwargs
+    )
 
 
 def peripheral_mirny(module, peripheral, **kwargs):


### PR DESCRIPTION
Add a property for the Grabber peripheral in the Kasli JSON hardware description schema that configures the number of ROI engines the Grabber peripheral gets in gateware:

```json
        {
            "type": "grabber",
            "ports": [ 1 ],
            "roi_engine_count": 32
        }
```

The number of ROI engines is limited to 32 such that calls to [`Grabber.gate_roi`](https://github.com/alpine-quantum-technologies/artiq/blob/2a97547187943c430af074b91f5c2ae662ed9086/artiq/coredevice/grabber.py#L53) are able to address all ROI engines (the `data` argument in `rtio_ouptut` is a 32-bit integer).

:warning: It is not clear whether the number of ROI engines needs to be a power of two. This constraint anyway cannot be enforced by the JSON schema (similarly to the number of SED lanes).