### PR TITLE
compiler: add host target

### DIFF
--- a/artiq/compiler/targets.py
+++ b/artiq/compiler/targets.py
@@ -94,6 +94,8 @@ class Target:
     tool_addr2line = "llvm-addr2line"
     tool_cxxfilt = "llvm-cxxfilt"
 
+    use_kernel_linker_script = True
+
     def __init__(self):
         self.llcontext = ll.Context()
 
@@ -185,7 +187,11 @@ class Target:
         """Link the relocatable objects into a shared library for this target."""
         with RunTool([self.tool_ld, "-shared", "--eh-frame-hdr"] +
                      self.additional_linker_options +
-                     ["-T" + os.path.join(os.path.dirname(__file__), "kernel.ld")] +
+                     (
+                         ["-T" + os.path.join(os.path.dirname(__file__), "kernel.ld")]
+                         if self.use_kernel_linker_script
+                         else []
+                     ) +
                      ["{{obj{}}}".format(index) for index in range(len(objects))] +
                      ["-x"] +
                      ["-o", "{output}"],
@@ -303,3 +309,15 @@ class CortexA9Target(Target):
     tool_strip = "llvm-strip"
     tool_addr2line = "llvm-addr2line"
     tool_cxxfilt = "llvm-cxxfilt"
+
+class X8664HostTarget(Target):
+    """Compile for a x86_64 host machine."""
+    triple = "x86_64-unknown-none-elf"
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+    features = ["soft-float"]
+    additional_linker_options = ["--gc-sections"]
+    print_function = "core_log"
+    now_pinning = False
+
+    # Build for the host machine, not for the coredevice's kernel CPU.
+    use_kernel_linker_script = False

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -12,7 +12,7 @@ from artiq.language.units import *
 
 from artiq.compiler.module import Module
 from artiq.compiler.embedding import Stitcher
-from artiq.compiler.targets import RV32IMATarget, RV32GTarget, CortexA9Target
+from artiq.compiler.targets import RV32IMATarget, RV32GTarget, CortexA9Target, X8664HostTarget
 
 from artiq.coredevice.comm_kernel import CommKernel, CommKernelDummy
 # Import for side effects (creating the exception classes).
@@ -81,6 +81,8 @@ class Core:
             self.target_cls = RV32IMATarget
         elif target == "cortexa9":
             self.target_cls = CortexA9Target
+        elif target == "x86_64-host":
+            self.target_cls = X8664HostTarget
         else:
             raise ValueError("Unsupported target")
         self.coarse_ref_period = ref_period*ref_multiplier


### PR DESCRIPTION
Add a compiler target `x86_64-host` that allows compiling kernels for execution on a `x86_64` **host** machine.

The data layout is taken from the `rustc` configuration for the `x86_64-unknown-none` target.

The target is set in the `device_db`:

```python
    "core": {
        "type": "local",
        "module": "artiq.coredevice.core",
        "class": "Core",
        "arguments": {"host": core_addr, "ref_period": 1e-09, "target": "x86_64-host"},
    },
```