### PR TITLE
mock timestamped inputs

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -151,7 +151,7 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(rtio_input_timestamp = ::rtio::input_timestamp),
     api!(mock_input_data = ::mock_input_data),
     api!(rtio_input_data = ::rtio_input_data),
-    api!(rtio_input_timestamped_data = ::rtio::input_timestamped_data),
+    api!(rtio_input_timestamped_data = ::rtio_input_timestamped_data),
 
     api!(dma_record_start = ::dma_record_start),
     api!(dma_record_stop = ::dma_record_stop),

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -23,6 +23,8 @@ use proto_artiq::{kernel_proto, rpc_proto};
 use kernel_proto::*;
 use board_misoc::csr;
 use riscv::register::{mcause, mepc, mtval};
+use rtio::TimestampedData;
+
 
 fn send(request: &Message) {
     unsafe { mailbox::send(request as *const _ as usize) }

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -332,9 +332,9 @@ extern fn rtio_input_timestamped_data(timeout: i64, channel: i32) -> Timestamped
 		    let _ = rtio::input_timestamped_data(timeout, channel); // discard the value
 		}
 		TimestampedData {
-            timestamp: 0,
-            data: data as i32
-        }
+	            timestamp: 0,
+        	    data: data as i32
+        	}
 	    }
 	}
     }

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -316,6 +316,28 @@ extern fn rtio_input_data(channel: i32) -> i32 {
     }
 }
 
+/// Replacement for `rtio::input_timestamped_data` that serves mock data for the target channel
+/// if any exists. Does not attempt to mock the timestamp if mocked, always returns 0.
+extern fn rtio_input_timestamped_data(timeout: i64, channel: i32) -> TimestampedData {
+    unsafe {
+	let item = MOCK_INPUT_DATA.iter_mut().find(|entry| entry.channel == channel);
+	match item {
+	    None => rtio::input_timestamped_data(timeout, channel),
+	    Some(desc) => {
+		let data = desc.data[desc.current];
+		desc.current = (desc.current + 1) % desc.data.len();
+		if desc.consume_events {
+		    let _ = rtio::input_timestamped_data(timeout, channel); // discard the value
+		}
+		TimestampedData {
+            timestamp: 0,
+            data: data as i32
+        }
+	    }
+	}
+    }
+}
+
 const DMA_BUFFER_SIZE: usize = 64 * 1024;
 
 struct DmaRecorder {

--- a/artiq/firmware/ksupport/rtio.rs
+++ b/artiq/firmware/ksupport/rtio.rs
@@ -1,7 +1,7 @@
 #[repr(C)]
 pub struct TimestampedData {
-    timestamp: i64,
-    data: i32,
+    pub timestamp: i64,
+    pub data: i32,
 }
 
 #[cfg(has_rtio)]


### PR DESCRIPTION
This fixes an issue with ARTIQ 8 where `grabber.input_mu()` was switched over to use `rtio_input_timestamped()` which was not mocked before. Now the tests pass for ARTIQ 8 too (manually triggered and with this ARTIQ flashed).