### PR TITLE
Fix unsound exception string handling.

### DIFF
--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -12,25 +12,31 @@
 
 use core::mem;
 use cslice::AsCSlice;
-use unwind as uw;
 use libc::{c_int, c_void};
+use unwind as uw;
 
-use eh::{self, dwarf::{self, EHAction, EHContext}};
+use eh::{
+    self,
+    dwarf::{self, EHAction, EHContext},
+};
 
 pub type Exception<'a> = eh::eh_artiq::Exception<'a>;
 pub type StackPointerBacktrace = eh::eh_artiq::StackPointerBacktrace;
 
-type _Unwind_Stop_Fn = extern "C" fn(version: c_int,
-                                     actions: uw::_Unwind_Action,
-                                     exception_class: uw::_Unwind_Exception_Class,
-                                     exception_object: *mut uw::_Unwind_Exception,
-                                     context: *mut uw::_Unwind_Context,
-                                     stop_parameter: *mut c_void)
-                                    -> uw::_Unwind_Reason_Code;
-extern {
-    fn _Unwind_ForcedUnwind(exception: *mut uw::_Unwind_Exception,
-                            stop_fn: _Unwind_Stop_Fn,
-                            stop_parameter: *mut c_void) -> uw::_Unwind_Reason_Code;
+type _Unwind_Stop_Fn = extern "C" fn(
+    version: c_int,
+    actions: uw::_Unwind_Action,
+    exception_class: uw::_Unwind_Exception_Class,
+    exception_object: *mut uw::_Unwind_Exception,
+    context: *mut uw::_Unwind_Context,
+    stop_parameter: *mut c_void,
+) -> uw::_Unwind_Reason_Code;
+extern "C" {
+    fn _Unwind_ForcedUnwind(
+        exception: *mut uw::_Unwind_Exception,
+        stop_fn: _Unwind_Stop_Fn,
+        stop_parameter: *mut c_void,
+    ) -> uw::_Unwind_Reason_Code;
 }
 
 pub static mut PAYLOAD_ADDRESS: usize = 0;
@@ -56,9 +62,9 @@ struct ExceptionBuffer {
 }
 
 const EXCEPTION: uw::_Unwind_Exception = uw::_Unwind_Exception {
-    exception_class:   EXCEPTION_CLASS,
+    exception_class: EXCEPTION_CLASS,
     exception_cleanup: cleanup,
-    private:           [0; uw::unwinder_private_data_size],
+    private: [0; uw::unwinder_private_data_size],
 };
 
 static mut EXCEPTION_BUFFER: ExceptionBuffer = ExceptionBuffer {
@@ -70,12 +76,12 @@ static mut EXCEPTION_BUFFER: ExceptionBuffer = ExceptionBuffer {
     stack_pointers: [StackPointerBacktrace {
         stack_pointer: 0,
         initial_backtrace_size: 0,
-        current_backtrace_size: 0
+        current_backtrace_size: 0,
     }; MAX_INFLIGHT_EXCEPTIONS + 1],
-    exception_count: 0
+    exception_count: 0,
 };
 
-pub unsafe extern fn reset_exception_buffer(payload_addr: usize) {
+pub unsafe extern "C" fn reset_exception_buffer(payload_addr: usize) {
     EXCEPTION_BUFFER.uw_exceptions = [EXCEPTION; MAX_INFLIGHT_EXCEPTIONS];
     EXCEPTION_BUFFER.exceptions = [None; MAX_INFLIGHT_EXCEPTIONS + 1];
     EXCEPTION_BUFFER.exception_stack = [-1; MAX_INFLIGHT_EXCEPTIONS + 1];
@@ -96,16 +102,17 @@ const UNWIND_DATA_REG: (i32, i32) = (10, 11); // X10, X11
 #[cfg(any(target_arch = "riscv32"))]
 const UNW_FP_REG: c_int = 2;
 
-#[export_name="__artiq_personality"]
-pub extern fn personality(version: c_int,
-                          _actions: uw::_Unwind_Action,
-                          uw_exception_class: uw::_Unwind_Exception_Class,
-                          uw_exception: *mut uw::_Unwind_Exception,
-                          context: *mut uw::_Unwind_Context)
-                         -> uw::_Unwind_Reason_Code {
+#[export_name = "__artiq_personality"]
+pub extern "C" fn personality(
+    version: c_int,
+    _actions: uw::_Unwind_Action,
+    uw_exception_class: uw::_Unwind_Exception_Class,
+    uw_exception: *mut uw::_Unwind_Exception,
+    context: *mut uw::_Unwind_Context,
+) -> uw::_Unwind_Reason_Code {
     unsafe {
         if version != 1 || uw_exception_class != EXCEPTION_CLASS {
-            return uw::_URC_FATAL_PHASE1_ERROR
+            return uw::_URC_FATAL_PHASE1_ERROR;
         }
 
         let lsda = uw::_Unwind_GetLanguageSpecificData(context) as *const u8;
@@ -122,7 +129,9 @@ pub extern fn personality(version: c_int,
 
         let index = EXCEPTION_BUFFER.exception_stack[EXCEPTION_BUFFER.exception_count - 1];
         assert!(index != -1);
-        let exception = EXCEPTION_BUFFER.exceptions[index as usize].as_ref().unwrap();
+        let exception = EXCEPTION_BUFFER.exceptions[index as usize]
+            .as_ref()
+            .unwrap();
         let id = exception.id;
 
         let eh_action = match dwarf::find_eh_action(lsda, &eh_context, id) {
@@ -132,14 +141,15 @@ pub extern fn personality(version: c_int,
 
         match eh_action {
             EHAction::None => return uw::_URC_CONTINUE_UNWIND,
-            EHAction::Cleanup(lpad) |
-            EHAction::Catch(lpad) => {
+            EHAction::Cleanup(lpad) | EHAction::Catch(lpad) => {
                 // Pass a pair of the unwinder exception and ARTIQ exception
                 // (which immediately follows).
-                uw::_Unwind_SetGR(context, UNWIND_DATA_REG.0,
-                                  uw_exception as uw::_Unwind_Word);
-                uw::_Unwind_SetGR(context, UNWIND_DATA_REG.1,
-                                  exception as *const _ as uw::_Unwind_Word);
+                uw::_Unwind_SetGR(context, UNWIND_DATA_REG.0, uw_exception as uw::_Unwind_Word);
+                uw::_Unwind_SetGR(
+                    context,
+                    UNWIND_DATA_REG.1,
+                    exception as *const _ as uw::_Unwind_Word,
+                );
                 uw::_Unwind_SetIP(context, lpad);
                 return uw::_URC_INSTALL_CONTEXT;
             }
@@ -148,12 +158,13 @@ pub extern fn personality(version: c_int,
     }
 }
 
-#[export_name="__artiq_raise"]
+#[export_name = "__artiq_raise"]
 pub unsafe extern "C-unwind" fn raise(exception: *const Exception) -> ! {
     let count = EXCEPTION_BUFFER.exception_count;
     let stack = &mut EXCEPTION_BUFFER.exception_stack;
     let diff = exception as isize - EXCEPTION_BUFFER.exceptions.as_ptr() as isize;
-    if 0 <= diff && diff <= (mem::size_of::<Option<Exception>>() * MAX_INFLIGHT_EXCEPTIONS) as isize {
+    if 0 <= diff && diff <= (mem::size_of::<Option<Exception>>() * MAX_INFLIGHT_EXCEPTIONS) as isize
+    {
         let index = diff / (mem::size_of::<Option<Exception>>() as isize);
         let mut found = false;
         for i in 0..=MAX_INFLIGHT_EXCEPTIONS + 1 {
@@ -172,8 +183,11 @@ pub unsafe extern "C-unwind" fn raise(exception: *const Exception) -> ! {
             }
         }
         assert!(found);
-        let _result = _Unwind_ForcedUnwind(&mut EXCEPTION_BUFFER.uw_exceptions[stack[count - 1] as usize],
-                                           stop_fn, core::ptr::null_mut());
+        let _result = _Unwind_ForcedUnwind(
+            &mut EXCEPTION_BUFFER.uw_exceptions[stack[count - 1] as usize],
+            stop_fn,
+            core::ptr::null_mut(),
+        );
     } else {
         if count < MAX_INFLIGHT_EXCEPTIONS {
             let exception = &*exception;
@@ -181,32 +195,34 @@ pub unsafe extern "C-unwind" fn raise(exception: *const Exception) -> ! {
                 // we should always be able to find a slot
                 if slot.is_none() {
                     *slot = Some(
-                        *mem::transmute::<*const Exception, *const Exception<'static>>
-                        (exception));
+                        *mem::transmute::<*const Exception, *const Exception<'static>>(exception),
+                    );
                     EXCEPTION_BUFFER.exception_stack[count] = i as isize;
-                    EXCEPTION_BUFFER.uw_exceptions[i].private =
-                        [0; uw::unwinder_private_data_size];
+                    EXCEPTION_BUFFER.uw_exceptions[i].private = [0; uw::unwinder_private_data_size];
                     EXCEPTION_BUFFER.stack_pointers[i] = StackPointerBacktrace {
                         stack_pointer: 0,
                         initial_backtrace_size: EXCEPTION_BUFFER.backtrace_size,
                         current_backtrace_size: 0,
                     };
                     EXCEPTION_BUFFER.exception_count += 1;
-                    let _result = _Unwind_ForcedUnwind(&mut EXCEPTION_BUFFER.uw_exceptions[i],
-                                                       stop_fn, core::ptr::null_mut());
+                    let _result = _Unwind_ForcedUnwind(
+                        &mut EXCEPTION_BUFFER.uw_exceptions[i],
+                        stop_fn,
+                        core::ptr::null_mut(),
+                    );
                 }
             }
         } else {
             // TODO: better reporting?
             let exception = Exception {
-                id:       get_exception_id("RuntimeError"),
-                file:     file!().as_c_slice(),
-                line:     line!(),
-                column:   column!(),
+                id: get_exception_id("RuntimeError"),
+                file: file!().as_c_slice(),
+                line: line!(),
+                column: column!(),
                 // https://github.com/rust-lang/rfcs/pull/1719
                 function: "__artiq_raise".as_c_slice(),
-                message:  "too many nested exceptions".as_c_slice(),
-                param:    [0, 0, 0]
+                message: "too many nested exceptions".as_c_slice(),
+                param: [0, 0, 0],
             };
             EXCEPTION_BUFFER.exceptions[MAX_INFLIGHT_EXCEPTIONS] = Some(mem::transmute(exception));
             EXCEPTION_BUFFER.stack_pointers[MAX_INFLIGHT_EXCEPTIONS] = Default::default();
@@ -217,18 +233,20 @@ pub unsafe extern "C-unwind" fn raise(exception: *const Exception) -> ! {
     unreachable!();
 }
 
-
-#[export_name="__artiq_resume"]
+#[export_name = "__artiq_resume"]
 pub unsafe extern "C-unwind" fn resume() -> ! {
     assert!(EXCEPTION_BUFFER.exception_count != 0);
     let i = EXCEPTION_BUFFER.exception_stack[EXCEPTION_BUFFER.exception_count - 1];
     assert!(i != -1);
-    let _result = _Unwind_ForcedUnwind(&mut EXCEPTION_BUFFER.uw_exceptions[i as usize],
-                                       stop_fn, core::ptr::null_mut());
+    let _result = _Unwind_ForcedUnwind(
+        &mut EXCEPTION_BUFFER.uw_exceptions[i as usize],
+        stop_fn,
+        core::ptr::null_mut(),
+    );
     unreachable!()
 }
 
-#[export_name="__artiq_end_catch"]
+#[export_name = "__artiq_end_catch"]
 pub unsafe extern "C-unwind" fn end_catch() {
     let mut count = EXCEPTION_BUFFER.exception_count;
     assert!(count != 0);
@@ -237,8 +255,7 @@ pub unsafe extern "C-unwind" fn end_catch() {
     let index = EXCEPTION_BUFFER.exception_stack[count - 1] as usize;
     EXCEPTION_BUFFER.exception_stack[count - 1] = -1;
     EXCEPTION_BUFFER.exceptions[index] = None;
-    let outer_sp = EXCEPTION_BUFFER.stack_pointers
-        [index].stack_pointer;
+    let outer_sp = EXCEPTION_BUFFER.stack_pointers[index].stack_pointer;
     count -= 1;
     for i in (0..count).rev() {
         let index = EXCEPTION_BUFFER.exception_stack[i];
@@ -262,8 +279,10 @@ pub unsafe extern "C-unwind" fn end_catch() {
     };
 }
 
-extern fn cleanup(_unwind_code: uw::_Unwind_Reason_Code,
-                  _uw_exception: *mut uw::_Unwind_Exception) {
+extern "C" fn cleanup(
+    _unwind_code: uw::_Unwind_Reason_Code,
+    _uw_exception: *mut uw::_Unwind_Exception,
+) {
     unimplemented!()
 }
 
@@ -273,18 +292,26 @@ fn uncaught_exception() -> ! {
         for i in 0..EXCEPTION_BUFFER.exception_count {
             if EXCEPTION_BUFFER.exception_stack[i] != i as isize {
                 // find the correct index
-                let index = EXCEPTION_BUFFER.exception_stack
+                let index = EXCEPTION_BUFFER
+                    .exception_stack
                     .iter()
-                    .position(|v| *v == i as isize).unwrap();
+                    .position(|v| *v == i as isize)
+                    .unwrap();
                 let a = EXCEPTION_BUFFER.exception_stack[index];
                 let b = EXCEPTION_BUFFER.exception_stack[i];
                 assert!(a != -1 && b != -1);
-                core::mem::swap(&mut EXCEPTION_BUFFER.exception_stack[index],
-                                &mut EXCEPTION_BUFFER.exception_stack[i]);
-                core::mem::swap(&mut EXCEPTION_BUFFER.exceptions[a as usize],
-                                &mut EXCEPTION_BUFFER.exceptions[b as usize]);
-                core::mem::swap(&mut EXCEPTION_BUFFER.stack_pointers[a as usize],
-                                &mut EXCEPTION_BUFFER.stack_pointers[b as usize]);
+                core::mem::swap(
+                    &mut EXCEPTION_BUFFER.exception_stack[index],
+                    &mut EXCEPTION_BUFFER.exception_stack[i],
+                );
+                core::mem::swap(
+                    &mut EXCEPTION_BUFFER.exceptions[a as usize],
+                    &mut EXCEPTION_BUFFER.exceptions[b as usize],
+                );
+                core::mem::swap(
+                    &mut EXCEPTION_BUFFER.stack_pointers[a as usize],
+                    &mut EXCEPTION_BUFFER.stack_pointers[b as usize],
+                );
             }
         }
     }
@@ -292,18 +319,20 @@ fn uncaught_exception() -> ! {
         ::terminate(
             EXCEPTION_BUFFER.exceptions[..EXCEPTION_BUFFER.exception_count].as_ref(),
             EXCEPTION_BUFFER.stack_pointers[..EXCEPTION_BUFFER.exception_count].as_ref(),
-            EXCEPTION_BUFFER.backtrace[..EXCEPTION_BUFFER.backtrace_size].as_mut())
+            EXCEPTION_BUFFER.backtrace[..EXCEPTION_BUFFER.backtrace_size].as_mut(),
+        )
     }
 }
 
-
 // stop function which would be executed when we unwind each frame
-extern fn stop_fn(_version: c_int,
-                  actions: uw::_Unwind_Action,
-                  _uw_exception_class: uw::_Unwind_Exception_Class,
-                  _uw_exception: *mut uw::_Unwind_Exception,
-                  context: *mut uw::_Unwind_Context,
-                  _stop_parameter: *mut c_void) -> uw::_Unwind_Reason_Code {
+extern "C" fn stop_fn(
+    _version: c_int,
+    actions: uw::_Unwind_Action,
+    _uw_exception_class: uw::_Unwind_Exception_Class,
+    _uw_exception: *mut uw::_Unwind_Exception,
+    context: *mut uw::_Unwind_Context,
+    _stop_parameter: *mut c_void,
+) -> uw::_Unwind_Reason_Code {
     unsafe {
         let backtrace_size = EXCEPTION_BUFFER.backtrace_size;
         if backtrace_size < MAX_BACKTRACE_SIZE {
@@ -313,7 +342,8 @@ extern fn stop_fn(_version: c_int,
                 let ip = ip - PAYLOAD_ADDRESS;
                 EXCEPTION_BUFFER.backtrace[backtrace_size] = (ip, fp);
                 EXCEPTION_BUFFER.backtrace_size += 1;
-                let last_index = EXCEPTION_BUFFER.exception_stack[EXCEPTION_BUFFER.exception_count - 1];
+                let last_index =
+                    EXCEPTION_BUFFER.exception_stack[EXCEPTION_BUFFER.exception_count - 1];
                 assert!(last_index != -1);
                 let sp_info = &mut EXCEPTION_BUFFER.stack_pointers[last_index as usize];
                 sp_info.stack_pointer = fp;
@@ -347,7 +377,7 @@ static EXCEPTION_ID_LOOKUP: [(&str, u32); 12] = [
 pub fn get_exception_id(name: &str) -> u32 {
     for (n, id) in EXCEPTION_ID_LOOKUP.iter() {
         if *n == name {
-            return *id
+            return *id;
         }
     }
     unimplemented!("unallocated internal exception id")
@@ -358,7 +388,7 @@ pub fn get_exception_id(name: &str) -> u32 {
 ///   * `id` set to `exn_id`
 ///   * `message` set to corresponding exception name from `EXCEPTION_ID_LOOKUP`
 ///
-/// The message is matched on host to ensure correct exception is being referred 
+/// The message is matched on host to ensure correct exception is being referred
 /// This test checks the synchronization of exception ids for runtime errors
 #[no_mangle]
 pub extern "C-unwind" fn test_exception_id_sync(exn_id: u32) {
@@ -366,16 +396,15 @@ pub extern "C-unwind" fn test_exception_id_sync(exn_id: u32) {
         .iter()
         .find_map(|&(name, id)| if id == exn_id { Some(name) } else { None })
         .unwrap_or("unallocated internal exception id");
-    
+
     let exn = Exception {
-        id:       exn_id,
-        file:     file!().as_c_slice(),
-        line:     0,
-        column:   0,
+        id: exn_id,
+        file: file!().as_c_slice(),
+        line: 0,
+        column: 0,
         function: "test_exception_id_sync".as_c_slice(),
-        message:  message.as_c_slice(),
-        param:    [0, 0, 0]
+        message: message.as_c_slice(),
+        param: [0, 0, 0],
     };
     unsafe { raise(&exn) };
 }
-

--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -11,7 +11,6 @@
 #![allow(non_camel_case_types)]
 
 use core::mem;
-use cslice::AsCSlice;
 use libc::{c_int, c_void};
 use unwind as uw;
 
@@ -216,12 +215,12 @@ pub unsafe extern "C-unwind" fn raise(exception: *const Exception) -> ! {
             // TODO: better reporting?
             let exception = Exception {
                 id: get_exception_id("RuntimeError"),
-                file: file!().as_c_slice(),
+                file: file!().into(),
                 line: line!(),
                 column: column!(),
                 // https://github.com/rust-lang/rfcs/pull/1719
-                function: "__artiq_raise".as_c_slice(),
-                message: "too many nested exceptions".as_c_slice(),
+                function: "__artiq_raise".into(),
+                message: "too many nested exceptions".into(),
                 param: [0, 0, 0],
             };
             EXCEPTION_BUFFER.exceptions[MAX_INFLIGHT_EXCEPTIONS] = Some(mem::transmute(exception));
@@ -399,11 +398,11 @@ pub extern "C-unwind" fn test_exception_id_sync(exn_id: u32) {
 
     let exn = Exception {
         id: exn_id,
-        file: file!().as_c_slice(),
+        file: file!().into(),
         line: 0,
         column: 0,
-        function: "test_exception_id_sync".as_c_slice(),
-        message: message.as_c_slice(),
+        function: "test_exception_id_sync".into(),
+        message: message.into(),
         param: [0, 0, 0],
     };
     unsafe { raise(&exn) };

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -1,30 +1,28 @@
-#![feature(lang_items, asm, panic_unwind, libc,
-           panic_info_message, nll, c_unwind)]
+#![feature(lang_items, asm, panic_unwind, libc, panic_info_message, nll, c_unwind)]
 #![no_std]
 
+extern crate cslice;
 extern crate libc;
 extern crate unwind;
-extern crate cslice;
 
+extern crate board_artiq;
+extern crate board_misoc;
+extern crate dyld;
 extern crate eh;
 extern crate io;
-extern crate dyld;
-extern crate board_misoc;
-extern crate board_artiq;
 extern crate proto_artiq;
 extern crate riscv;
 
-use core::{mem, ptr, slice, str, convert::TryFrom};
-use cslice::CSlice;
-use io::Cursor;
-use dyld::Library;
 use board_artiq::{mailbox, rpc_queue};
-use proto_artiq::{kernel_proto, rpc_proto};
-use kernel_proto::*;
 use board_misoc::csr;
+use core::{convert::TryFrom, mem, ptr, slice, str};
+use cslice::CSlice;
+use dyld::Library;
+use io::Cursor;
+use kernel_proto::*;
+use proto_artiq::{kernel_proto, rpc_proto};
 use riscv::register::{mcause, mepc, mtval};
 use rtio::TimestampedData;
-
 
 fn send(request: &Message) {
     unsafe { mailbox::send(request as *const _ as usize) }
@@ -33,7 +31,9 @@ fn send(request: &Message) {
 
 fn recv<R, F: FnOnce(&Message) -> R>(f: F) -> R {
     let mut msg_ptr = 0;
-    while msg_ptr == 0 { msg_ptr = mailbox::receive(); }
+    while msg_ptr == 0 {
+        msg_ptr = mailbox::receive();
+    }
     let result = f(unsafe { &*(msg_ptr as *const Message) });
     mailbox::acknowledge();
     result
@@ -57,15 +57,19 @@ macro_rules! recv {
                 loop {}
             }
         })
-    }
+    };
 }
 
 #[no_mangle] // https://github.com/rust-lang/rust/issues/{38281,51647}
 #[panic_handler]
 pub fn panic_fmt(info: &core::panic::PanicInfo) -> ! {
     if let Some(location) = info.location() {
-        send(&Log(format_args!("panic at {}:{}:{}",
-                               location.file(), location.line(), location.column())));
+        send(&Log(format_args!(
+            "panic at {}:{}:{}",
+            location.file(),
+            location.line(),
+            location.column()
+        )));
     } else {
         send(&Log(format_args!("panic at unknown location")));
     }
@@ -88,61 +92,65 @@ macro_rules! println {
 }
 
 macro_rules! raise {
-    ($name:expr, $message:expr, $param0:expr, $param1:expr, $param2:expr) => ({
+    ($name:expr, $message:expr, $param0:expr, $param1:expr, $param2:expr) => {{
         use cslice::AsCSlice;
         let name_id = $crate::eh_artiq::get_exception_id($name);
         let exn = $crate::eh_artiq::Exception {
-            id:       name_id,
-            file:     file!().as_c_slice(),
-            line:     line!(),
-            column:   column!(),
+            id: name_id,
+            file: file!().as_c_slice(),
+            line: line!(),
+            column: column!(),
             // https://github.com/rust-lang/rfcs/pull/1719
             function: "(Rust function)".as_c_slice(),
-            message:  $message.as_c_slice(),
-            param:    [$param0, $param1, $param2]
+            message: $message.as_c_slice(),
+            param: [$param0, $param1, $param2],
         };
         #[allow(unused_unsafe)]
-        unsafe { $crate::eh_artiq::raise(&exn) }
-    });
-    ($name:expr, $message:expr) => ({
+        unsafe {
+            $crate::eh_artiq::raise(&exn)
+        }
+    }};
+    ($name:expr, $message:expr) => {{
         raise!($name, $message, 0, 0, 0)
-    });
+    }};
 }
 
-mod eh_artiq;
 mod api;
-mod rtio;
+mod eh_artiq;
 mod nrt_bus;
+mod rtio;
 
 static mut LIBRARY: Option<Library<'static>> = None;
 
 #[no_mangle]
-pub extern fn send_to_core_log(text: CSlice<u8>) {
+pub extern "C" fn send_to_core_log(text: CSlice<u8>) {
     match str::from_utf8(text.as_ref()) {
         Ok(s) => send(&LogSlice(s)),
         Err(e) => {
-            send(&LogSlice(str::from_utf8(&text.as_ref()[..e.valid_up_to()]).unwrap()));
+            send(&LogSlice(
+                str::from_utf8(&text.as_ref()[..e.valid_up_to()]).unwrap(),
+            ));
             send(&LogSlice("(invalid utf-8)\n"));
         }
     }
 }
 
 #[no_mangle]
-pub extern fn send_to_rtio_log(text: CSlice<u8>) {
+pub extern "C" fn send_to_rtio_log(text: CSlice<u8>) {
     rtio::log(text.as_ref())
 }
 
-extern fn rpc_send(service: u32, tag: &CSlice<u8>, data: *const *const ()) {
+extern "C" fn rpc_send(service: u32, tag: &CSlice<u8>, data: *const *const ()) {
     while !rpc_queue::empty() {}
     send(&RpcSend {
-        async:   false,
+        async: false,
         service: service,
-        tag:     tag.as_ref(),
-        data:    data
+        tag: tag.as_ref(),
+        data: data,
     })
 }
 
-extern fn rpc_send_async(service: u32, tag: &CSlice<u8>, data: *const *const ()) {
+extern "C" fn rpc_send_async(service: u32, tag: &CSlice<u8>, data: *const *const ()) {
     while rpc_queue::full() {}
     rpc_queue::enqueue(|mut slice| {
         let length = {
@@ -151,19 +159,19 @@ extern fn rpc_send_async(service: u32, tag: &CSlice<u8>, data: *const *const ())
             writer.position()
         };
         io::ProtoWrite::write_u32(&mut slice, length as u32)
-    }).unwrap_or_else(|err| {
+    })
+    .unwrap_or_else(|err| {
         assert!(err == io::Error::UnexpectedEnd);
 
         while !rpc_queue::empty() {}
         send(&RpcSend {
-            async:   true,
+            async: true,
             service: service,
-            tag:     tag.as_ref(),
-            data:    data
+            tag: tag.as_ref(),
+            data: data,
         })
     })
 }
-
 
 /// Receives the result from an RPC call into the given memory buffer.
 ///
@@ -200,20 +208,22 @@ extern "C-unwind" fn rpc_recv(slot: *mut ()) -> usize {
     })
 }
 
-fn terminate(exceptions: &'static [Option<eh_artiq::Exception<'static>>],
-             stack_pointers: &'static [eh_artiq::StackPointerBacktrace],
-             backtrace: &mut [(usize, usize)]) -> ! {
+fn terminate(
+    exceptions: &'static [Option<eh_artiq::Exception<'static>>],
+    stack_pointers: &'static [eh_artiq::StackPointerBacktrace],
+    backtrace: &mut [(usize, usize)],
+) -> ! {
     send(&RunException {
         exceptions,
         stack_pointers,
-        backtrace
+        backtrace,
     });
     loop {}
 }
 
-extern fn cache_get<'a>(key: &CSlice<u8>) -> *const CSlice<'a, i32> {
+extern "C" fn cache_get<'a>(key: &CSlice<u8>) -> *const CSlice<'a, i32> {
     send(&CacheGetRequest {
-        key:   str::from_utf8(key.as_ref()).unwrap()
+        key: str::from_utf8(key.as_ref()).unwrap(),
     });
     recv!(&CacheGetReply { value } => {
         value
@@ -222,8 +232,8 @@ extern fn cache_get<'a>(key: &CSlice<u8>) -> *const CSlice<'a, i32> {
 
 extern "C-unwind" fn cache_put(key: &CSlice<u8>, list: &CSlice<i32>) {
     send(&CachePutRequest {
-        key:   str::from_utf8(key.as_ref()).unwrap(),
-        value: list.as_ref()
+        key: str::from_utf8(key.as_ref()).unwrap(),
+        value: list.as_ref(),
     });
     recv!(&CachePutReply { succeeded } => {
         if !succeeded {
@@ -240,7 +250,8 @@ struct InputDataMock {
     consume_events: bool,
 }
 
-static mut MOCK_INPUT_DATA: heapless::Vec<InputDataMock, heapless::consts::U16> = heapless::Vec(heapless::i::Vec::new());
+static mut MOCK_INPUT_DATA: heapless::Vec<InputDataMock, heapless::consts::U16> =
+    heapless::Vec(heapless::i::Vec::new());
 
 /// Register mock RTIO input data.
 ///
@@ -259,104 +270,117 @@ static mut MOCK_INPUT_DATA: heapless::Vec<InputDataMock, heapless::consts::U16> 
 ///   mock for the target channel.
 /// * `consume_events` - if `true`, also consume the underlying event. Block if
 ///   no such event exists.
-extern fn mock_input_data(channel: i32, data: &CSlice<i32>, consume_events: bool) {
+extern "C" fn mock_input_data(channel: i32, data: &CSlice<i32>, consume_events: bool) {
     let data = if let Ok(data) = heapless::Vec::from_slice(data.as_ref()) {
-	data
+        data
     } else {
-	raise!("RuntimeError", "Mock data too long");
+        raise!("RuntimeError", "Mock data too long");
     };
 
     unsafe {
-	let index = MOCK_INPUT_DATA.iter().position(|entry| entry.channel == channel);
-	match (index, data.len()) {
-	    (None, len) if len > 0 => {
-		// new entry
-		if MOCK_INPUT_DATA.push(InputDataMock {
-		    channel,
-		    data,
-		    current: 0,
-		    consume_events,
-		}).is_err() {
-		    raise!("RuntimeError", "Cannot add mock data entry");
-		}
-	    },
-	    (Some(index), len) if len == 0 => {
-		// empty data: remove entry
-		MOCK_INPUT_DATA.swap_remove(index);
-	    }
-	    (Some(index), _) => {
-		// non-empty data: update entry
-		MOCK_INPUT_DATA.swap_remove(index);
-		MOCK_INPUT_DATA.push(InputDataMock {
-		    channel,
-		    data,
-		    current: 0,
-		    consume_events,
-		}).unwrap();
-	    }
-	    _ => (), // new entry, empty data: ignore
-	}
+        let index = MOCK_INPUT_DATA
+            .iter()
+            .position(|entry| entry.channel == channel);
+        match (index, data.len()) {
+            (None, len) if len > 0 => {
+                // new entry
+                if MOCK_INPUT_DATA
+                    .push(InputDataMock {
+                        channel,
+                        data,
+                        current: 0,
+                        consume_events,
+                    })
+                    .is_err()
+                {
+                    raise!("RuntimeError", "Cannot add mock data entry");
+                }
+            }
+            (Some(index), len) if len == 0 => {
+                // empty data: remove entry
+                MOCK_INPUT_DATA.swap_remove(index);
+            }
+            (Some(index), _) => {
+                // non-empty data: update entry
+                MOCK_INPUT_DATA.swap_remove(index);
+                MOCK_INPUT_DATA
+                    .push(InputDataMock {
+                        channel,
+                        data,
+                        current: 0,
+                        consume_events,
+                    })
+                    .unwrap();
+            }
+            _ => (), // new entry, empty data: ignore
+        }
     }
 }
 
 /// Replacement for `rtio::input_data` that serves mock data for the target channel
 /// if any exists.
-extern fn rtio_input_data(channel: i32) -> i32 {
+extern "C" fn rtio_input_data(channel: i32) -> i32 {
     unsafe {
-	let item = MOCK_INPUT_DATA.iter_mut().find(|entry| entry.channel == channel);
-	match item {
-	    None => rtio::input_data(channel),
-	    Some(desc) => {
-		let data = desc.data[desc.current];
-		desc.current = (desc.current + 1) % desc.data.len();
-		if desc.consume_events {
-		    let _ = rtio::input_data(channel); // discard the value
-		}
-		data
-	    }
-	}
+        let item = MOCK_INPUT_DATA
+            .iter_mut()
+            .find(|entry| entry.channel == channel);
+        match item {
+            None => rtio::input_data(channel),
+            Some(desc) => {
+                let data = desc.data[desc.current];
+                desc.current = (desc.current + 1) % desc.data.len();
+                if desc.consume_events {
+                    let _ = rtio::input_data(channel); // discard the value
+                }
+                data
+            }
+        }
     }
 }
 
 /// Replacement for `rtio::input_timestamped_data` that serves mock data for the target channel
 /// if any exists. Does not attempt to mock the timestamp if mocked, always returns 0.
-extern fn rtio_input_timestamped_data(timeout: i64, channel: i32) -> TimestampedData {
+extern "C" fn rtio_input_timestamped_data(timeout: i64, channel: i32) -> TimestampedData {
     unsafe {
-	let item = MOCK_INPUT_DATA.iter_mut().find(|entry| entry.channel == channel);
-	match item {
-	    None => rtio::input_timestamped_data(timeout, channel),
-	    Some(desc) => {
-		let data = desc.data[desc.current];
-		desc.current = (desc.current + 1) % desc.data.len();
-		if desc.consume_events {
-		    let _ = rtio::input_timestamped_data(timeout, channel); // discard the value
-		}
-		TimestampedData {
-	            timestamp: 0,
-        	    data: data as i32
-        	}
-	    }
-	}
+        let item = MOCK_INPUT_DATA
+            .iter_mut()
+            .find(|entry| entry.channel == channel);
+        match item {
+            None => rtio::input_timestamped_data(timeout, channel),
+            Some(desc) => {
+                let data = desc.data[desc.current];
+                desc.current = (desc.current + 1) % desc.data.len();
+                if desc.consume_events {
+                    let _ = rtio::input_timestamped_data(timeout, channel); // discard the value
+                }
+                TimestampedData {
+                    timestamp: 0,
+                    data: data as i32,
+                }
+            }
+        }
     }
 }
 
 const DMA_BUFFER_SIZE: usize = 64 * 1024;
 
 struct DmaRecorder {
-    active:   bool,
+    active: bool,
     data_len: usize,
-    buffer:   [u8; DMA_BUFFER_SIZE],
+    buffer: [u8; DMA_BUFFER_SIZE],
 }
 
 static mut DMA_RECORDER: DmaRecorder = DmaRecorder {
-    active:   false,
+    active: false,
     data_len: 0,
-    buffer:   [0; DMA_BUFFER_SIZE],
+    buffer: [0; DMA_BUFFER_SIZE],
 };
 
 fn dma_record_flush() {
     unsafe {
-        send(&DmaRecordAppend(&DMA_RECORDER.buffer[..DMA_RECORDER.data_len]));
+        send(&DmaRecordAppend(
+            &DMA_RECORDER.buffer[..DMA_RECORDER.data_len],
+        ));
         DMA_RECORDER.data_len = 0;
     }
 }
@@ -370,10 +394,15 @@ extern "C-unwind" fn dma_record_start(name: &CSlice<u8>) {
         }
 
         let library = LIBRARY.as_ref().unwrap();
-        library.rebind(b"rtio_output",
-                       dma_record_output as *const () as u32).unwrap();
-        library.rebind(b"rtio_output_wide",
-                       dma_record_output_wide as *const () as u32).unwrap();
+        library
+            .rebind(b"rtio_output", dma_record_output as *const () as u32)
+            .unwrap();
+        library
+            .rebind(
+                b"rtio_output_wide",
+                dma_record_output_wide as *const () as u32,
+            )
+            .unwrap();
 
         DMA_RECORDER.active = true;
         send(&DmaRecordStart(name));
@@ -389,78 +418,84 @@ extern "C-unwind" fn dma_record_stop(duration: i64, enable_ddma: bool) {
         }
 
         let library = LIBRARY.as_ref().unwrap();
-        library.rebind(b"rtio_output",
-                       rtio::output as *const () as u32).unwrap();
-        library.rebind(b"rtio_output_wide",
-                       rtio::output_wide as *const () as u32).unwrap();
+        library
+            .rebind(b"rtio_output", rtio::output as *const () as u32)
+            .unwrap();
+        library
+            .rebind(b"rtio_output_wide", rtio::output_wide as *const () as u32)
+            .unwrap();
 
         DMA_RECORDER.active = false;
         send(&DmaRecordStop {
             duration: duration as u64,
-            enable_ddma: enable_ddma
+            enable_ddma: enable_ddma,
         });
     }
 }
 
 #[inline(always)]
-unsafe fn dma_record_output_prepare(timestamp: i64, target: i32,
-                                    words: usize) -> &'static mut [u8] {
+unsafe fn dma_record_output_prepare(
+    timestamp: i64,
+    target: i32,
+    words: usize,
+) -> &'static mut [u8] {
     // See gateware/rtio/dma.py.
-    const HEADER_LENGTH: usize = /*length*/1 + /*channel*/3 + /*timestamp*/8 + /*address*/1;
+    const HEADER_LENGTH: usize = /*length*/ 1 + /*channel*/3 + /*timestamp*/8 + /*address*/1;
     let length = HEADER_LENGTH + /*data*/words * 4;
 
     if DMA_RECORDER.buffer.len() - DMA_RECORDER.data_len < length {
         dma_record_flush()
     }
 
-    let record = &mut DMA_RECORDER.buffer[DMA_RECORDER.data_len..
-                                          DMA_RECORDER.data_len + length];
+    let record = &mut DMA_RECORDER.buffer[DMA_RECORDER.data_len..DMA_RECORDER.data_len + length];
     DMA_RECORDER.data_len += length;
 
     let (header, data) = record.split_at_mut(HEADER_LENGTH);
 
     header.copy_from_slice(&[
-        (length    >>  0) as u8,
-        (target    >>  8) as u8,
-        (target    >>  16) as u8,
-        (target    >>  24) as u8,
-        (timestamp >>  0) as u8,
-        (timestamp >>  8) as u8,
+        (length >> 0) as u8,
+        (target >> 8) as u8,
+        (target >> 16) as u8,
+        (target >> 24) as u8,
+        (timestamp >> 0) as u8,
+        (timestamp >> 8) as u8,
         (timestamp >> 16) as u8,
         (timestamp >> 24) as u8,
         (timestamp >> 32) as u8,
         (timestamp >> 40) as u8,
         (timestamp >> 48) as u8,
         (timestamp >> 56) as u8,
-        (target    >>  0) as u8,
+        (target >> 0) as u8,
     ]);
 
     data
 }
 
-extern fn dma_record_output(target: i32, word: i32) {
+extern "C" fn dma_record_output(target: i32, word: i32) {
     unsafe {
-        let timestamp = ((csr::rtio::now_hi_read() as i64) << 32) | (csr::rtio::now_lo_read() as i64);
+        let timestamp =
+            ((csr::rtio::now_hi_read() as i64) << 32) | (csr::rtio::now_lo_read() as i64);
         let data = dma_record_output_prepare(timestamp, target, 1);
         data.copy_from_slice(&[
-            (word >>  0) as u8,
-            (word >>  8) as u8,
+            (word >> 0) as u8,
+            (word >> 8) as u8,
             (word >> 16) as u8,
             (word >> 24) as u8,
         ]);
     }
 }
 
-extern fn dma_record_output_wide(target: i32, words: &CSlice<i32>) {
+extern "C" fn dma_record_output_wide(target: i32, words: &CSlice<i32>) {
     assert!(words.len() <= 16); // enforce the hardware limit
 
     unsafe {
-        let timestamp = ((csr::rtio::now_hi_read() as i64) << 32) | (csr::rtio::now_lo_read() as i64);
+        let timestamp =
+            ((csr::rtio::now_hi_read() as i64) << 32) | (csr::rtio::now_lo_read() as i64);
         let mut data = dma_record_output_prepare(timestamp, target, words.len());
         for word in words.as_ref().iter() {
             data[..4].copy_from_slice(&[
-                (word >>  0) as u8,
-                (word >>  8) as u8,
+                (word >> 0) as u8,
+                (word >> 8) as u8,
                 (word >> 16) as u8,
                 (word >> 24) as u8,
             ]);
@@ -469,7 +504,7 @@ extern fn dma_record_output_wide(target: i32, words: &CSlice<i32>) {
     }
 }
 
-extern fn dma_erase(name: &CSlice<u8>) {
+extern "C" fn dma_erase(name: &CSlice<u8>) {
     let name = str::from_utf8(name.as_ref()).unwrap();
 
     send(&DmaEraseRequest { name: name });
@@ -478,7 +513,7 @@ extern fn dma_erase(name: &CSlice<u8>) {
 #[repr(C)]
 struct DmaTrace {
     duration: i64,
-    address:  i32,
+    address: i32,
     uses_ddma: bool,
 }
 
@@ -495,10 +530,10 @@ extern "C-unwind" fn dma_retrieve(name: &CSlice<u8>) -> DmaTrace {
             }),
             None => Err(())
         }
-    }).unwrap_or_else(|()| {
+    })
+    .unwrap_or_else(|()| {
         println!("DMA trace called {:?} not found", name);
-        raise!("DMAError",
-            "DMA trace not found");
+        raise!("DMAError", "DMA trace not found");
     })
 }
 
@@ -514,7 +549,10 @@ extern "C-unwind" fn dma_playback(timestamp: i64, ptr: i32, _uses_ddma: bool) {
         csr::rtio_dma::enable_write(1);
         #[cfg(has_drtio)]
         if _uses_ddma {
-            send(&DmaStartRemoteRequest { id: ptr as i32, timestamp: timestamp });
+            send(&DmaStartRemoteRequest {
+                id: ptr as i32,
+                timestamp: timestamp,
+            });
         }
         while csr::rtio_dma::enable_read() != 0 {}
         csr::cri_con::selected_write(0);
@@ -525,9 +563,13 @@ extern "C-unwind" fn dma_playback(timestamp: i64, ptr: i32, _uses_ddma: bool) {
             let channel = csr::rtio_dma::error_channel_read();
             csr::rtio_dma::error_write(1);
             if error & 1 != 0 {
-                raise!("RTIOUnderflow",
+                raise!(
+                    "RTIOUnderflow",
                     "RTIO underflow at channel {rtio_channel_info:0}, {1} mu",
-                    channel as i64, timestamp as i64, 0);
+                    channel as i64,
+                    timestamp as i64,
+                    0
+                );
             }
             if error & 2 != 0 {
                 raise!("RTIODestinationUnreachable",
@@ -569,7 +611,10 @@ extern "C-unwind" fn dma_playback(_timestamp: i64, _ptr: i32, _uses_ddma: bool) 
 extern "C-unwind" fn dma_playback(timestamp: i64, ptr: i32, _uses_ddma: bool) {
     // DDMA is always used on satellites, so the `uses_ddma` setting is ignored
     // StartRemoteRequest reused as "normal" start request
-    send(&DmaStartRemoteRequest { id: ptr as i32, timestamp: timestamp });
+    send(&DmaStartRemoteRequest {
+        id: ptr as i32,
+        timestamp: timestamp,
+    });
     // skip awaitremoterequest - it's a given
     recv!(&DmaAwaitRemoteReply { timeout, error, channel, timestamp } => {
         if timeout {
@@ -589,15 +634,13 @@ extern "C-unwind" fn dma_playback(timestamp: i64, ptr: i32, _uses_ddma: bool) {
     });
 }
 
-
 extern "C-unwind" fn subkernel_load_run(id: u32, destination: u8, run: bool) {
-    let timestamp = unsafe {
-        ((csr::rtio::now_hi_read() as u64) << 32) | (csr::rtio::now_lo_read() as u64)
-    };
-    send(&SubkernelLoadRunRequest { 
-        id: id, 
-        destination: destination, 
-        run: run, 
+    let timestamp =
+        unsafe { ((csr::rtio::now_hi_read() as u64) << 32) | (csr::rtio::now_lo_read() as u64) };
+    send(&SubkernelLoadRunRequest {
+        id: id,
+        destination: destination,
+        run: run,
         timestamp: timestamp,
     });
     recv!(&SubkernelLoadRunReply { succeeded } => {
@@ -609,19 +652,25 @@ extern "C-unwind" fn subkernel_load_run(id: u32, destination: u8, run: bool) {
 }
 
 extern "C-unwind" fn subkernel_await_finish(id: u32, timeout: i64) {
-    send(&SubkernelAwaitFinishRequest { id: id, timeout: timeout });
+    send(&SubkernelAwaitFinishRequest {
+        id: id,
+        timeout: timeout,
+    });
     recv(move |request| {
-        if let SubkernelAwaitFinishReply = request { }
-        else if let SubkernelError(status) = request {
+        if let SubkernelAwaitFinishReply = request {
+        } else if let SubkernelError(status) = request {
             match status {
-                SubkernelStatus::IncorrectState => raise!("SubkernelError",
-                    "Subkernel not running"),
-                SubkernelStatus::Timeout => raise!("SubkernelError",
-                    "Subkernel timed out"),
-                SubkernelStatus::CommLost => raise!("SubkernelError",
-                    "Lost communication with satellite"),
-                SubkernelStatus::OtherError => raise!("SubkernelError",
-                    "An error occurred during subkernel operation"),
+                SubkernelStatus::IncorrectState => {
+                    raise!("SubkernelError", "Subkernel not running")
+                }
+                SubkernelStatus::Timeout => raise!("SubkernelError", "Subkernel timed out"),
+                SubkernelStatus::CommLost => {
+                    raise!("SubkernelError", "Lost communication with satellite")
+                }
+                SubkernelStatus::OtherError => raise!(
+                    "SubkernelError",
+                    "An error occurred during subkernel operation"
+                ),
                 SubkernelStatus::Exception(e) => unsafe { crate::eh_artiq::raise(e) },
             }
         } else {
@@ -631,36 +680,57 @@ extern "C-unwind" fn subkernel_await_finish(id: u32, timeout: i64) {
     })
 }
 
-extern fn subkernel_send_message(id: u32, is_return: bool, destination: u8, 
-    count: u8, tag: &CSlice<u8>, data: *const *const ()) {
-    send(&SubkernelMsgSend { 
+extern "C" fn subkernel_send_message(
+    id: u32,
+    is_return: bool,
+    destination: u8,
+    count: u8,
+    tag: &CSlice<u8>,
+    data: *const *const (),
+) {
+    send(&SubkernelMsgSend {
         id: id,
         destination: if is_return { None } else { Some(destination) },
         count: count,
         tag: tag.as_ref(),
-        data: data 
+        data: data,
     });
 }
 
-extern "C-unwind" fn subkernel_await_message(id: i32, timeout: i64, tags: &CSlice<u8>, min: u8, max: u8) -> u8 {
-    send(&SubkernelMsgRecvRequest { id: id, timeout: timeout, tags: tags.as_ref() });
+extern "C-unwind" fn subkernel_await_message(
+    id: i32,
+    timeout: i64,
+    tags: &CSlice<u8>,
+    min: u8,
+    max: u8,
+) -> u8 {
+    send(&SubkernelMsgRecvRequest {
+        id: id,
+        timeout: timeout,
+        tags: tags.as_ref(),
+    });
     recv(move |request| {
         if let SubkernelMsgRecvReply { count } = request {
             if count < &min || count > &max {
-                raise!("SubkernelError",
-                    "Received less or more arguments than expected");
+                raise!(
+                    "SubkernelError",
+                    "Received less or more arguments than expected"
+                );
             }
             *count
         } else if let SubkernelError(status) = request {
             match status {
-                SubkernelStatus::IncorrectState => raise!("SubkernelError",
-                    "Subkernel not running"),
-                SubkernelStatus::Timeout => raise!("SubkernelError",
-                    "Subkernel timed out"),
-                SubkernelStatus::CommLost => raise!("SubkernelError",
-                    "Lost communication with satellite"),
-                SubkernelStatus::OtherError => raise!("SubkernelError",
-                    "An error occurred during subkernel operation"),
+                SubkernelStatus::IncorrectState => {
+                    raise!("SubkernelError", "Subkernel not running")
+                }
+                SubkernelStatus::Timeout => raise!("SubkernelError", "Subkernel timed out"),
+                SubkernelStatus::CommLost => {
+                    raise!("SubkernelError", "Lost communication with satellite")
+                }
+                SubkernelStatus::OtherError => raise!(
+                    "SubkernelError",
+                    "An error occurred during subkernel operation"
+                ),
                 SubkernelStatus::Exception(e) => unsafe { crate::eh_artiq::raise(e) },
             }
         } else {
@@ -674,13 +744,13 @@ extern "C-unwind" fn subkernel_await_message(id: i32, timeout: i64, tags: &CSlic
 unsafe fn attribute_writeback(typeinfo: *const ()) {
     struct Attr {
         offset: usize,
-        tag:    CSlice<'static, u8>,
-        name:   CSlice<'static, u8>
+        tag: CSlice<'static, u8>,
+        name: CSlice<'static, u8>,
     }
 
     struct Type {
         attributes: *const *const Attr,
-        objects:    *const *const ()
+        objects: *const *const (),
     }
 
     let mut tys = typeinfo as *const *const Type;
@@ -699,11 +769,16 @@ unsafe fn attribute_writeback(typeinfo: *const ()) {
                 attributes = attributes.offset(1);
 
                 if (*attribute).tag.len() > 0 {
-                    rpc_send_async(0, &(*attribute).tag, [
-                        &object as *const _ as *const (),
-                        &(*attribute).name as *const _ as *const (),
-                        (object as usize + (*attribute).offset) as *const ()
-                    ].as_ptr());
+                    rpc_send_async(
+                        0,
+                        &(*attribute).tag,
+                        [
+                            &object as *const _ as *const (),
+                            &(*attribute).name as *const _ as *const (),
+                            (object as usize + (*attribute).offset) as *const (),
+                        ]
+                        .as_ptr(),
+                    );
                 }
             }
         }
@@ -715,9 +790,10 @@ static mut STACK_GUARD_BASE: usize = 0x0;
 #[no_mangle]
 pub unsafe fn main() {
     eh_artiq::reset_exception_buffer(KERNELCPU_PAYLOAD_ADDRESS);
-    let image = slice::from_raw_parts_mut(kernel_proto::KERNELCPU_PAYLOAD_ADDRESS as *mut u8,
-                                          kernel_proto::KERNELCPU_LAST_ADDRESS -
-                                          kernel_proto::KERNELCPU_PAYLOAD_ADDRESS);
+    let image = slice::from_raw_parts_mut(
+        kernel_proto::KERNELCPU_PAYLOAD_ADDRESS as *mut u8,
+        kernel_proto::KERNELCPU_LAST_ADDRESS - kernel_proto::KERNELCPU_PAYLOAD_ADDRESS,
+    );
 
     let library = recv!(&LoadRequest(library) => {
         match Library::load(library, image, &api::resolve) {
@@ -795,7 +871,12 @@ pub unsafe extern "C-unwind" fn exception(_regs: *const u32) {
                    cause, u32::try_from(pc).unwrap(), mtval);
         }
     }
-    panic!("{:?} at PC {:#08x}, trap value {:#08x}", cause, u32::try_from(pc).unwrap(), mtval);
+    panic!(
+        "{:?} at PC {:#08x}, trap value {:#08x}",
+        cause,
+        u32::try_from(pc).unwrap(),
+        mtval
+    );
 }
 
 #[no_mangle]

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -97,12 +97,12 @@ macro_rules! raise {
         let name_id = $crate::eh_artiq::get_exception_id($name);
         let exn = $crate::eh_artiq::Exception {
             id: name_id,
-            file: file!().as_c_slice(),
+            file: file!().into(),
             line: line!(),
             column: column!(),
             // https://github.com/rust-lang/rfcs/pull/1719
-            function: "(Rust function)".as_c_slice(),
-            message: $message.as_c_slice(),
+            function: "(Rust function)".into(),
+            message: $message.into(),
             param: [$param0, $param1, $param2],
         };
         #[allow(unused_unsafe)]

--- a/artiq/firmware/libeh/eh_artiq.rs
+++ b/artiq/firmware/libeh/eh_artiq.rs
@@ -1,29 +1,84 @@
-// ARTIQ Exception struct declaration
-use cslice::CSlice;
+//! ARTIQ Exception struct declaration.
 
-// Note: CSlice within an exception may not be actual cslice, they may be strings that exist only
-// in the host. If the length == usize:MAX, the pointer is actually a string key in the host.
-#[repr(C)]
+use core::{marker::PhantomData, slice, str};
+
+/// Exception string value representation.
+///
+/// This can be a string literal or a string key on the host.
 #[derive(Copy, Clone)]
+pub enum ExceptionStrValue<'a> {
+    HostKey(u32),
+    String(Result<&'a str, str::Utf8Error>),
+}
+
+/// Exception string representation.
+///
+/// This can be a string literal or a string key on the host.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ExceptionStr<'a> {
+    value: usize,
+    len: u32,
+    s: PhantomData<&'a str>,
+}
+
+impl<'a> ExceptionStr<'a> {
+    /// Returns the string value.
+    pub fn value(&self) -> ExceptionStrValue<'a> {
+        if self.len == u32::MAX {
+            ExceptionStrValue::HostKey(self.value as u32)
+        } else {
+            // SAFETY: Length is not `u32::MAX`, so it is a string.
+            let s = unsafe { slice::from_raw_parts(self.value as *const u8, self.len as usize) };
+            ExceptionStrValue::String(str::from_utf8(s.as_ref()))
+        }
+    }
+
+    /// Returns the string value, if this is a string.
+    pub fn as_str(&self) -> Option<Result<&'a str, core::str::Utf8Error>> {
+        match self.value() {
+            ExceptionStrValue::String(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> From<u32> for ExceptionStr<'a> {
+    fn from(key: u32) -> Self {
+        ExceptionStr {
+            value: key as usize,
+            len: u32::MAX,
+            s: PhantomData,
+        }
+    }
+}
+
+impl<'a> From<&'a str> for ExceptionStr<'a> {
+    fn from(s: &'a str) -> Self {
+        ExceptionStr {
+            value: s.as_ptr() as usize,
+            len: s.len() as u32,
+            s: PhantomData,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Exception<'a> {
     pub id: u32,
-    pub file: CSlice<'a, u8>,
+    pub file: ExceptionStr<'a>,
     pub line: u32,
     pub column: u32,
-    pub function: CSlice<'a, u8>,
-    pub message: CSlice<'a, u8>,
+    pub function: ExceptionStr<'a>,
+    pub message: ExceptionStr<'a>,
     pub param: [i64; 3],
 }
 
-fn str_err(_: core::str::Utf8Error) -> core::fmt::Error {
-    core::fmt::Error
-}
-
-fn exception_str<'a>(s: &'a CSlice<'a, u8>) -> Result<&'a str, core::str::Utf8Error> {
-    if s.len() == usize::MAX {
-        Ok("<host string>")
-    } else {
-        core::str::from_utf8(s.as_ref())
+fn fmt_exception_str<'a>(s: ExceptionStr<'a>) -> Result<&'a str, core::fmt::Error> {
+    match s.value() {
+        ExceptionStrValue::HostKey(_) => Ok("<host string>"),
+        ExceptionStrValue::String(s) => s.map_err(|_| core::fmt::Error),
     }
 }
 
@@ -33,11 +88,11 @@ impl<'a> core::fmt::Debug for Exception<'a> {
             f,
             "Exception {} from {} in {}:{}:{}, message: {}",
             self.id,
-            exception_str(&self.function).map_err(str_err)?,
-            exception_str(&self.file).map_err(str_err)?,
+            fmt_exception_str(self.function)?,
+            fmt_exception_str(self.file)?,
             self.line,
             self.column,
-            exception_str(&self.message).map_err(str_err)?
+            fmt_exception_str(self.message)?,
         )
     }
 }

--- a/artiq/firmware/libeh/eh_artiq.rs
+++ b/artiq/firmware/libeh/eh_artiq.rs
@@ -6,13 +6,13 @@ use cslice::CSlice;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Exception<'a> {
-    pub id:       u32,
-    pub file:     CSlice<'a, u8>,
-    pub line:     u32,
-    pub column:   u32,
+    pub id: u32,
+    pub file: CSlice<'a, u8>,
+    pub line: u32,
+    pub column: u32,
     pub function: CSlice<'a, u8>,
-    pub message:  CSlice<'a, u8>,
-    pub param:    [i64; 3]
+    pub message: CSlice<'a, u8>,
+    pub param: [i64; 3],
 }
 
 fn str_err(_: core::str::Utf8Error) -> core::fmt::Error {
@@ -29,12 +29,16 @@ fn exception_str<'a>(s: &'a CSlice<'a, u8>) -> Result<&'a str, core::str::Utf8Er
 
 impl<'a> core::fmt::Debug for Exception<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Exception {} from {} in {}:{}:{}, message: {}",
+        write!(
+            f,
+            "Exception {} from {} in {}:{}:{}, message: {}",
             self.id,
             exception_str(&self.function).map_err(str_err)?,
             exception_str(&self.file).map_err(str_err)?,
-            self.line, self.column,
-            exception_str(&self.message).map_err(str_err)?)
+            self.line,
+            self.column,
+            exception_str(&self.message).map_err(str_err)?
+        )
     }
 }
 
@@ -44,4 +48,3 @@ pub struct StackPointerBacktrace {
     pub initial_backtrace_size: usize,
     pub current_backtrace_size: usize,
 }
-

--- a/artiq/firmware/libproto_artiq/session_proto.rs
+++ b/artiq/firmware/libproto_artiq/session_proto.rs
@@ -1,9 +1,9 @@
-use core::{str, str::Utf8Error, slice};
-use alloc::{vec::Vec, format, collections::BTreeMap, string::String};
-use eh::eh_artiq::{Exception, StackPointerBacktrace};
+use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
+use core::{slice, str, str::Utf8Error};
 use cslice::CSlice;
+use eh::eh_artiq::{Exception, StackPointerBacktrace};
 
-use io::{Read, ProtoRead, Write, ProtoWrite, Error as IoError, ReadStringError};
+use io::{Error as IoError, ProtoRead, ProtoWrite, Read, ReadStringError, Write};
 
 pub type DeviceMap = BTreeMap<u32, String>;
 
@@ -18,7 +18,7 @@ pub enum Error<T> {
     #[fail(display = "invalid UTF-8: {}", _0)]
     Utf8(Utf8Error),
     #[fail(display = "{}", _0)]
-    Io(#[cause] IoError<T>)
+    Io(#[cause] IoError<T>),
 }
 
 impl<T> From<IoError<T>> for Error<T> {
@@ -31,13 +31,14 @@ impl<T> From<ReadStringError<IoError<T>>> for Error<T> {
     fn from(value: ReadStringError<IoError<T>>) -> Error<T> {
         match value {
             ReadStringError::Utf8(err) => Error::Utf8(err),
-            ReadStringError::Other(err) => Error::Io(err)
+            ReadStringError::Other(err) => Error::Io(err),
         }
     }
 }
 
 pub fn read_magic<R>(reader: &mut R) -> Result<(), Error<R::ReadError>>
-    where R: Read + ?Sized
+where
+    R: Read + ?Sized,
 {
     const MAGIC: &'static [u8] = b"ARTIQ coredev\n";
 
@@ -51,18 +52,22 @@ pub fn read_magic<R>(reader: &mut R) -> Result<(), Error<R::ReadError>>
 }
 
 fn read_sync<R>(reader: &mut R) -> Result<(), IoError<R::ReadError>>
-    where R: Read + ?Sized
+where
+    R: Read + ?Sized,
 {
     let mut sync = [0; 4];
     for i in 0.. {
         sync[i % 4] = reader.read_u8()?;
-        if sync == [0x5a; 4] { break }
+        if sync == [0x5a; 4] {
+            break;
+        }
     }
     Ok(())
 }
 
 fn write_sync<W>(writer: &mut W) -> Result<(), IoError<W::WriteError>>
-    where W: Write + ?Sized
+where
+    W: Write + ?Sized,
 {
     writer.write_all(&[0x5a; 4])
 }
@@ -74,84 +79,99 @@ pub enum Request {
     LoadKernel(Vec<u8>),
     RunKernel,
 
-    RpcReply { tag: Vec<u8> },
+    RpcReply {
+        tag: Vec<u8>,
+    },
     RpcException {
-        id:       u32,
-        message:  u32,
-        param:    [i64; 3],
-        file:     u32,
-        line:     u32,
-        column:   u32,
+        id: u32,
+        message: u32,
+        param: [i64; 3],
+        file: u32,
+        line: u32,
+        column: u32,
         function: u32,
     },
 
-    UploadSubkernel { id: u32, destination: u8, kernel: Vec<u8> },
+    UploadSubkernel {
+        id: u32,
+        destination: u8,
+        kernel: Vec<u8>,
+    },
 }
 
 #[derive(Debug)]
 pub enum Reply<'a> {
     SystemInfo {
         ident: &'a str,
-        finished_cleanly: bool
+        finished_cleanly: bool,
     },
 
     LoadCompleted,
     LoadFailed(&'a str),
 
     KernelFinished {
-        async_errors: u8
+        async_errors: u8,
     },
     KernelStartupFailed,
     KernelException {
         exceptions: &'a [Option<Exception<'a>>],
         stack_pointers: &'a [StackPointerBacktrace],
         backtrace: &'a [(usize, usize)],
-        async_errors: u8
+        async_errors: u8,
     },
 
-    RpcRequest { async: bool },
+    RpcRequest {
+        async: bool,
+    },
 
     ClockFailure,
 }
 
 impl Request {
     pub fn read_from<R>(reader: &mut R) -> Result<Self, Error<R::ReadError>>
-        where R: Read + ?Sized
+    where
+        R: Read + ?Sized,
     {
         read_sync(reader)?;
         Ok(match reader.read_u8()? {
-            3  => Request::SystemInfo,
+            3 => Request::SystemInfo,
 
-            5  => Request::LoadKernel(reader.read_bytes()?),
-            6  => Request::RunKernel,
+            5 => Request::LoadKernel(reader.read_bytes()?),
+            6 => Request::RunKernel,
 
-            7  => Request::RpcReply {
-                tag: reader.read_bytes()?
+            7 => Request::RpcReply {
+                tag: reader.read_bytes()?,
             },
-            8  => Request::RpcException {
-                id:       reader.read_u32()?,
-                message:  reader.read_u32()?,
-                param:    [reader.read_u64()? as i64,
-                           reader.read_u64()? as i64,
-                           reader.read_u64()? as i64],
-                file:     reader.read_u32()?,
-                line:     reader.read_u32()?,
-                column:   reader.read_u32()?,
-                function: reader.read_u32()?
+            8 => Request::RpcException {
+                id: reader.read_u32()?,
+                message: reader.read_u32()?,
+                param: [
+                    reader.read_u64()? as i64,
+                    reader.read_u64()? as i64,
+                    reader.read_u64()? as i64,
+                ],
+                file: reader.read_u32()?,
+                line: reader.read_u32()?,
+                column: reader.read_u32()?,
+                function: reader.read_u32()?,
             },
             9 => Request::UploadSubkernel {
                 id: reader.read_u32()?,
                 destination: reader.read_u8()?,
-                kernel: reader.read_bytes()?
+                kernel: reader.read_bytes()?,
             },
 
-            ty  => return Err(Error::UnknownPacket(ty))
+            ty => return Err(Error::UnknownPacket(ty)),
         })
     }
 }
 
-fn write_exception_string<'a, W>(writer: &mut W, s: &CSlice<'a, u8>) -> Result<(), IoError<W::WriteError>>
-    where W: Write + ?Sized
+fn write_exception_string<'a, W>(
+    writer: &mut W,
+    s: &CSlice<'a, u8>,
+) -> Result<(), IoError<W::WriteError>>
+where
+    W: Write + ?Sized,
 {
     if s.len() == usize::MAX {
         writer.write_u32(u32::MAX)?;
@@ -164,37 +184,41 @@ fn write_exception_string<'a, W>(writer: &mut W, s: &CSlice<'a, u8>) -> Result<(
 
 impl<'a> Reply<'a> {
     pub fn write_to<W>(&self, writer: &mut W) -> Result<(), IoError<W::WriteError>>
-        where W: Write + ?Sized
+    where
+        W: Write + ?Sized,
     {
         write_sync(writer)?;
         match *self {
-            Reply::SystemInfo { ident, finished_cleanly } => {
+            Reply::SystemInfo {
+                ident,
+                finished_cleanly,
+            } => {
                 writer.write_u8(2)?;
                 writer.write(b"AROR")?;
                 writer.write_string(ident)?;
                 writer.write_u8(finished_cleanly as u8)?;
-            },
+            }
 
             Reply::LoadCompleted => {
                 writer.write_u8(5)?;
-            },
+            }
             Reply::LoadFailed(reason) => {
                 writer.write_u8(6)?;
                 writer.write_string(reason)?;
-            },
+            }
 
             Reply::KernelFinished { async_errors } => {
                 writer.write_u8(7)?;
                 writer.write_u8(async_errors)?;
-            },
+            }
             Reply::KernelStartupFailed => {
                 writer.write_u8(8)?;
-            },
+            }
             Reply::KernelException {
                 exceptions,
                 stack_pointers,
                 backtrace,
-                async_errors
+                async_errors,
             } => {
                 writer.write_u8(9)?;
                 writer.write_u32(exceptions.len() as u32)?;
@@ -205,9 +229,24 @@ impl<'a> Reply<'a> {
                         // exception with host string
                         write_exception_string(writer, &exception.message)?;
                     } else {
-                        let msg = str::from_utf8(unsafe { slice::from_raw_parts(exception.message.as_ptr(), exception.message.len()) }).unwrap()
-                          .replace("{rtio_channel_info:0}", &format!("0x{:04x}:{}", exception.param[0], resolve_channel_name(exception.param[0] as u32)));
-                        write_exception_string(writer, unsafe { &CSlice::new(msg.as_ptr(), msg.len()) })?;
+                        let msg = str::from_utf8(unsafe {
+                            slice::from_raw_parts(
+                                exception.message.as_ptr(),
+                                exception.message.len(),
+                            )
+                        })
+                        .unwrap()
+                        .replace(
+                            "{rtio_channel_info:0}",
+                            &format!(
+                                "0x{:04x}:{}",
+                                exception.param[0],
+                                resolve_channel_name(exception.param[0] as u32)
+                            ),
+                        );
+                        write_exception_string(writer, unsafe {
+                            &CSlice::new(msg.as_ptr(), msg.len())
+                        })?;
                     }
                     writer.write_u64(exception.param[0] as u64)?;
                     writer.write_u64(exception.param[1] as u64)?;
@@ -230,34 +269,38 @@ impl<'a> Reply<'a> {
                     writer.write_u32(sp as u32)?;
                 }
                 writer.write_u8(async_errors)?;
-            },
+            }
 
             Reply::RpcRequest { async } => {
                 writer.write_u8(10)?;
                 writer.write_u8(async as u8)?;
-            },
+            }
 
             Reply::ClockFailure => {
                 writer.write_u8(15)?;
-            },
+            }
         }
         Ok(())
     }
 }
 
 pub fn set_device_map(device_map: DeviceMap) {
-    unsafe { RTIO_DEVICE_MAP = Some(device_map); }
+    unsafe {
+        RTIO_DEVICE_MAP = Some(device_map);
+    }
 }
 
 fn _resolve_channel_name(channel: u32, device_map: &Option<DeviceMap>) -> String {
     if let Some(dev_map) = device_map {
         match dev_map.get(&channel) {
             Some(val) => val.clone(),
-            None => String::from("unknown")
+            None => String::from("unknown"),
         }
-    } else { String::from("unknown") }
+    } else {
+        String::from("unknown")
+    }
 }
 
 pub fn resolve_channel_name(channel: u32) -> String {
-    _resolve_channel_name(channel, unsafe{&RTIO_DEVICE_MAP})
+    _resolve_channel_name(channel, unsafe { &RTIO_DEVICE_MAP })
 }

--- a/artiq/firmware/libproto_artiq/session_proto.rs
+++ b/artiq/firmware/libproto_artiq/session_proto.rs
@@ -1,7 +1,6 @@
 use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
-use core::{slice, str, str::Utf8Error};
-use cslice::CSlice;
-use eh::eh_artiq::{Exception, StackPointerBacktrace};
+use core::{str, str::Utf8Error};
+use eh::eh_artiq::{Exception, ExceptionStr, ExceptionStrValue, StackPointerBacktrace};
 
 use io::{Error as IoError, ProtoRead, ProtoWrite, Read, ReadStringError, Write};
 
@@ -168,17 +167,21 @@ impl Request {
 
 fn write_exception_string<'a, W>(
     writer: &mut W,
-    s: &CSlice<'a, u8>,
+    s: ExceptionStr<'a>,
 ) -> Result<(), IoError<W::WriteError>>
 where
     W: Write + ?Sized,
 {
-    if s.len() == usize::MAX {
-        writer.write_u32(u32::MAX)?;
-        writer.write_u32(s.as_ptr() as u32)?;
-    } else {
-        writer.write_string(core::str::from_utf8(s.as_ref()).unwrap())?;
+    match s.value() {
+        ExceptionStrValue::HostKey(host_key) => {
+            writer.write_u32(u32::MAX)?;
+            writer.write_u32(host_key)?;
+        }
+        ExceptionStrValue::String(s) => {
+            writer.write_string(s.unwrap())?;
+        }
     }
+
     Ok(())
 }
 
@@ -225,36 +228,31 @@ impl<'a> Reply<'a> {
                 for exception in exceptions.iter() {
                     let exception = exception.as_ref().unwrap();
                     writer.write_u32(exception.id as u32)?;
-                    if exception.message.len() == usize::MAX {
-                        // exception with host string
-                        write_exception_string(writer, &exception.message)?;
-                    } else {
-                        let msg = str::from_utf8(unsafe {
-                            slice::from_raw_parts(
-                                exception.message.as_ptr(),
-                                exception.message.len(),
-                            )
-                        })
-                        .unwrap()
-                        .replace(
-                            "{rtio_channel_info:0}",
-                            &format!(
-                                "0x{:04x}:{}",
-                                exception.param[0],
-                                resolve_channel_name(exception.param[0] as u32)
-                            ),
-                        );
-                        write_exception_string(writer, unsafe {
-                            &CSlice::new(msg.as_ptr(), msg.len())
-                        })?;
+
+                    match exception.message.value() {
+                        ExceptionStrValue::HostKey(host_key) => {
+                            write_exception_string(writer, exception.message)?;
+                        }
+                        ExceptionStrValue::String(s) => {
+                            let msg = s.unwrap().replace(
+                                "{rtio_channel_info:0}",
+                                &format!(
+                                    "0x{:04x}:{}",
+                                    exception.param[0],
+                                    resolve_channel_name(exception.param[0] as u32)
+                                ),
+                            );
+                            write_exception_string(writer, ExceptionStr::from(msg.as_str()))?;
+                        }
                     }
+
                     writer.write_u64(exception.param[0] as u64)?;
                     writer.write_u64(exception.param[1] as u64)?;
                     writer.write_u64(exception.param[2] as u64)?;
-                    write_exception_string(writer, &exception.file)?;
+                    write_exception_string(writer, exception.file)?;
                     writer.write_u32(exception.line)?;
                     writer.write_u32(exception.column)?;
-                    write_exception_string(writer, &exception.function)?;
+                    write_exception_string(writer, exception.function)?;
                 }
 
                 for sp in stack_pointers.iter() {

--- a/artiq/firmware/runtime/kernel.rs
+++ b/artiq/firmware/runtime/kernel.rs
@@ -88,24 +88,26 @@ pub fn validate(ptr: usize) -> bool {
     ptr >= KERNELCPU_EXEC_ADDRESS && ptr <= KERNELCPU_LAST_ADDRESS
 }
 
-
 #[cfg(has_drtio)]
 pub mod subkernel {
-    use alloc::{vec::Vec, collections::btree_map::BTreeMap};
+    use alloc::{collections::btree_map::BTreeMap, vec::Vec};
     use board_artiq::drtio_routing::RoutingTable;
     use board_misoc::clock;
-    use proto_artiq::{drtioaux_proto::{PayloadStatus, MASTER_PAYLOAD_MAX_SIZE}, rpc_proto as rpc};
-    use io::{Cursor, ProtoRead};
-    use eh::eh_artiq::Exception;
     use cslice::CSlice;
+    use eh::eh_artiq::Exception;
+    use io::{Cursor, ProtoRead};
+    use proto_artiq::{
+        drtioaux_proto::{PayloadStatus, MASTER_PAYLOAD_MAX_SIZE},
+        rpc_proto as rpc,
+    };
     use rtio_mgt::drtio;
-    use sched::{Io, Mutex, Error as SchedError};
+    use sched::{Error as SchedError, Io, Mutex};
 
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub enum FinishStatus {
         Ok,
         CommLost,
-        Exception(u8) // exception source
+        Exception(u8), // exception source
     }
 
     #[derive(Debug, PartialEq, Clone, Copy)]
@@ -143,12 +145,12 @@ pub mod subkernel {
 
     impl From<SchedError> for Error {
         fn from(value: SchedError) -> Error {
-                Error::SchedError(value)
+            Error::SchedError(value)
         }
     }
 
     impl From<io::Error<!>> for Error {
-        fn from(_value: io::Error<!>) -> Error  {
+        fn from(_value: io::Error<!>) -> Error {
             Error::RpcIoError
         }
     }
@@ -156,13 +158,13 @@ pub mod subkernel {
     pub struct SubkernelFinished {
         pub id: u32,
         pub comm_lost: bool,
-        pub exception: Option<Vec<u8>>
+        pub exception: Option<Vec<u8>>,
     }
 
     struct Subkernel {
         pub destination: u8,
         pub data: Vec<u8>,
-        pub state: SubkernelState
+        pub state: SubkernelState,
     }
 
     impl Subkernel {
@@ -170,39 +172,81 @@ pub mod subkernel {
             Subkernel {
                 destination: destination,
                 data: data,
-                state: SubkernelState::NotLoaded
+                state: SubkernelState::NotLoaded,
             }
         }
     }
 
     static mut SUBKERNELS: BTreeMap<u32, Subkernel> = BTreeMap::new();
 
-    pub fn add_subkernel(io: &Io, subkernel_mutex: &Mutex, id: u32, destination: u8, kernel: Vec<u8>) -> Result<(), Error> {
+    pub fn add_subkernel(
+        io: &Io,
+        subkernel_mutex: &Mutex,
+        id: u32,
+        destination: u8,
+        kernel: Vec<u8>,
+    ) -> Result<(), Error> {
         let _lock = subkernel_mutex.lock(io)?;
-        unsafe { SUBKERNELS.insert(id, Subkernel::new(destination, kernel)); }
+        unsafe {
+            SUBKERNELS.insert(id, Subkernel::new(destination, kernel));
+        }
         Ok(())
     }
 
-    pub fn upload(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex, subkernel_mutex: &Mutex, 
-             routing_table: &RoutingTable, id: u32) -> Result<(), Error> {
+    pub fn upload(
+        io: &Io,
+        aux_mutex: &Mutex,
+        ddma_mutex: &Mutex,
+        subkernel_mutex: &Mutex,
+        routing_table: &RoutingTable,
+        id: u32,
+    ) -> Result<(), Error> {
         let _lock = subkernel_mutex.lock(io)?;
         let subkernel = unsafe { SUBKERNELS.get_mut(&id).unwrap() };
-        drtio::subkernel_upload(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, id, 
-            subkernel.destination, &subkernel.data)?;
-        subkernel.state = SubkernelState::Uploaded; 
-        Ok(()) 
+        drtio::subkernel_upload(
+            io,
+            aux_mutex,
+            ddma_mutex,
+            subkernel_mutex,
+            routing_table,
+            id,
+            subkernel.destination,
+            &subkernel.data,
+        )?;
+        subkernel.state = SubkernelState::Uploaded;
+        Ok(())
     }
 
-    pub fn load(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex, subkernel_mutex: &Mutex, routing_table: &RoutingTable,
-            id: u32, run: bool, timestamp: u64) -> Result<(), Error> {
+    pub fn load(
+        io: &Io,
+        aux_mutex: &Mutex,
+        ddma_mutex: &Mutex,
+        subkernel_mutex: &Mutex,
+        routing_table: &RoutingTable,
+        id: u32,
+        run: bool,
+        timestamp: u64,
+    ) -> Result<(), Error> {
         let _lock = subkernel_mutex.lock(io)?;
         let subkernel = unsafe { SUBKERNELS.get_mut(&id).unwrap() };
         if subkernel.state != SubkernelState::Uploaded {
-            error!("for id: {} expected Uploaded, got: {:?}", id, subkernel.state);
+            error!(
+                "for id: {} expected Uploaded, got: {:?}",
+                id, subkernel.state
+            );
             return Err(Error::IncorrectState);
         }
-        drtio::subkernel_load(io, aux_mutex, ddma_mutex, subkernel_mutex, 
-            routing_table, id, subkernel.destination, run, timestamp)?;
+        drtio::subkernel_load(
+            io,
+            aux_mutex,
+            ddma_mutex,
+            subkernel_mutex,
+            routing_table,
+            id,
+            subkernel.destination,
+            run,
+            timestamp,
+        )?;
         if run {
             subkernel.state = SubkernelState::Running;
         }
@@ -219,7 +263,13 @@ pub mod subkernel {
         Ok(())
     }
 
-    pub fn subkernel_finished(io: &Io, subkernel_mutex: &Mutex, id: u32, with_exception: bool, exception_src: u8) {
+    pub fn subkernel_finished(
+        io: &Io,
+        subkernel_mutex: &Mutex,
+        id: u32,
+        with_exception: bool,
+        exception_src: u8,
+    ) {
         // called upon receiving DRTIO SubkernelRunDone
         let _lock = subkernel_mutex.lock(io).unwrap();
         let subkernel = unsafe { SUBKERNELS.get_mut(&id) };
@@ -231,27 +281,47 @@ pub mod subkernel {
                     status: match with_exception {
                         true => FinishStatus::Exception(exception_src),
                         false => FinishStatus::Ok,
-                    }
+                    },
                 }
             }
         }
     }
 
-    pub fn destination_changed(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex, subkernel_mutex: &Mutex,
-             routing_table: &RoutingTable, destination: u8, up: bool) {
+    pub fn destination_changed(
+        io: &Io,
+        aux_mutex: &Mutex,
+        ddma_mutex: &Mutex,
+        subkernel_mutex: &Mutex,
+        routing_table: &RoutingTable,
+        destination: u8,
+        up: bool,
+    ) {
         let _lock = subkernel_mutex.lock(io).unwrap();
         let subkernels_iter = unsafe { SUBKERNELS.iter_mut() };
         for (id, subkernel) in subkernels_iter {
             if subkernel.destination == destination {
                 if up {
-                    match drtio::subkernel_upload(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, *id, destination, &subkernel.data)
-                    {
+                    match drtio::subkernel_upload(
+                        io,
+                        aux_mutex,
+                        ddma_mutex,
+                        subkernel_mutex,
+                        routing_table,
+                        *id,
+                        destination,
+                        &subkernel.data,
+                    ) {
                         Ok(_) => subkernel.state = SubkernelState::Uploaded,
-                        Err(e) => error!("Error adding subkernel on destination {}: {}", destination, e)
+                        Err(e) => error!(
+                            "Error adding subkernel on destination {}: {}",
+                            destination, e
+                        ),
                     }
                 } else {
                     subkernel.state = match subkernel.state {
-                        SubkernelState::Running => SubkernelState::Finished { status: FinishStatus::CommLost },
+                        SubkernelState::Running => SubkernelState::Finished {
+                            status: FinishStatus::CommLost,
+                        },
                         _ => SubkernelState::NotLoaded,
                     }
                 }
@@ -275,8 +345,7 @@ pub mod subkernel {
         }
     }
 
-    pub fn read_exception(buffer: &[u8]) -> Result<Exception, Error>
-    {
+    pub fn read_exception(buffer: &[u8]) -> Result<Exception, Error> {
         let mut reader = Cursor::new(buffer);
 
         let mut byte = reader.read_u8()?;
@@ -291,19 +360,28 @@ pub mod subkernel {
         let _len = reader.read_u32()?;
         // ignore the remaining exceptions, stack traces etc. - unwinding from another device would be unwise anyway
         Ok(Exception {
-            id:       reader.read_u32()?,
-            message:  read_exception_string(&mut reader)?,
-            param:    [reader.read_u64()? as i64, reader.read_u64()? as i64, reader.read_u64()? as i64],
-            file:     read_exception_string(&mut reader)?,
-            line:     reader.read_u32()?,
-            column:   reader.read_u32()?,
-            function: read_exception_string(&mut reader)?
+            id: reader.read_u32()?,
+            message: read_exception_string(&mut reader)?,
+            param: [
+                reader.read_u64()? as i64,
+                reader.read_u64()? as i64,
+                reader.read_u64()? as i64,
+            ],
+            file: read_exception_string(&mut reader)?,
+            line: reader.read_u32()?,
+            column: reader.read_u32()?,
+            function: read_exception_string(&mut reader)?,
         })
     }
 
-
-    pub fn retrieve_finish_status(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex, subkernel_mutex: &Mutex,
-        routing_table: &RoutingTable, id: u32) -> Result<SubkernelFinished, Error> {
+    pub fn retrieve_finish_status(
+        io: &Io,
+        aux_mutex: &Mutex,
+        ddma_mutex: &Mutex,
+        subkernel_mutex: &Mutex,
+        routing_table: &RoutingTable,
+        id: u32,
+    ) -> Result<SubkernelFinished, Error> {
         let _lock = subkernel_mutex.lock(io)?;
         let mut subkernel = unsafe { SUBKERNELS.get_mut(&id).unwrap() };
         match subkernel.state {
@@ -312,20 +390,33 @@ pub mod subkernel {
                 Ok(SubkernelFinished {
                     id: id,
                     comm_lost: status == FinishStatus::CommLost,
-                    exception: if let FinishStatus::Exception(dest) = status { 
-                        Some(drtio::subkernel_retrieve_exception(io, aux_mutex, ddma_mutex, subkernel_mutex,
-                            routing_table, dest)?) 
-                    } else { None }
+                    exception: if let FinishStatus::Exception(dest) = status {
+                        Some(drtio::subkernel_retrieve_exception(
+                            io,
+                            aux_mutex,
+                            ddma_mutex,
+                            subkernel_mutex,
+                            routing_table,
+                            dest,
+                        )?)
+                    } else {
+                        None
+                    },
                 })
-            },
-            _ => {
-                Err(Error::IncorrectState)
             }
+            _ => Err(Error::IncorrectState),
         }
     }
 
-    pub fn await_finish(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex, subkernel_mutex: &Mutex,
-        routing_table: &RoutingTable, id: u32, timeout: i64) -> Result<SubkernelFinished, Error> {
+    pub fn await_finish(
+        io: &Io,
+        aux_mutex: &Mutex,
+        ddma_mutex: &Mutex,
+        subkernel_mutex: &Mutex,
+        routing_table: &RoutingTable,
+        id: u32,
+        timeout: i64,
+    ) -> Result<SubkernelFinished, Error> {
         {
             let _lock = subkernel_mutex.lock(io)?;
             match unsafe { SUBKERNELS.get(&id).unwrap().state } {
@@ -348,20 +439,27 @@ pub mod subkernel {
             let subkernel = unsafe { SUBKERNELS.get(&id).unwrap() };
             match subkernel.state {
                 SubkernelState::Finished { .. } => true,
-                _ => false
+                _ => false,
             }
         })?;
         if timeout > 0 && clock::get_ms() > max_time {
             error!("Remote subkernel finish await timed out");
             return Err(Error::Timeout);
         }
-        retrieve_finish_status(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, id)
+        retrieve_finish_status(
+            io,
+            aux_mutex,
+            ddma_mutex,
+            subkernel_mutex,
+            routing_table,
+            id,
+        )
     }
 
     pub struct Message {
         from_id: u32,
         pub count: u8,
-        pub data: Vec<u8>
+        pub data: Vec<u8>,
     }
 
     // FIFO queue of messages
@@ -369,8 +467,14 @@ pub mod subkernel {
     // currently under construction message(s) (can be from multiple sources)
     static mut CURRENT_MESSAGES: BTreeMap<u32, Message> = BTreeMap::new();
 
-    pub fn message_handle_incoming(io: &Io, subkernel_mutex: &Mutex, 
-        id: u32, status: PayloadStatus, length: usize, data: &[u8; MASTER_PAYLOAD_MAX_SIZE]) {
+    pub fn message_handle_incoming(
+        io: &Io,
+        subkernel_mutex: &Mutex,
+        id: u32,
+        status: PayloadStatus,
+        length: usize,
+        data: &[u8; MASTER_PAYLOAD_MAX_SIZE],
+    ) {
         // called when receiving a message from satellite
         let _lock = match subkernel_mutex.lock(io) {
             Ok(lock) => lock,
@@ -381,7 +485,7 @@ pub mod subkernel {
         if subkernel.is_some() && subkernel.unwrap().state != SubkernelState::Running {
             warn!("received a message for a non-running subkernel #{}", id);
             // do not add messages for non-running or deleted subkernels
-            return
+            return;
         }
         if status.is_first() {
             unsafe {
@@ -391,36 +495,45 @@ pub mod subkernel {
         match unsafe { CURRENT_MESSAGES.get_mut(&id) } {
             Some(message) => message.data.extend(&data[..length]),
             None => unsafe {
-                CURRENT_MESSAGES.insert(id, Message {
-                    from_id: id,
-                    count: data[0],
-                    data: data[1..length].to_vec()
-                });
-            }
+                CURRENT_MESSAGES.insert(
+                    id,
+                    Message {
+                        from_id: id,
+                        count: data[0],
+                        data: data[1..length].to_vec(),
+                    },
+                );
+            },
         };
         if status.is_last() {
-            unsafe { 
+            unsafe {
                 // when done, remove from working queue
                 MESSAGE_QUEUE.push(CURRENT_MESSAGES.remove(&id).unwrap());
             };
         }
     }
 
-    pub fn message_await(io: &Io, subkernel_mutex: &Mutex, id: u32, timeout: i64
+    pub fn message_await(
+        io: &Io,
+        subkernel_mutex: &Mutex,
+        id: u32,
+        timeout: i64,
     ) -> Result<Message, Error> {
         let is_subkernel = {
             let _lock = subkernel_mutex.lock(io)?;
             let is_subkernel = unsafe { SUBKERNELS.get(&id).is_some() };
             if is_subkernel {
-            match unsafe { SUBKERNELS.get(&id).unwrap().state } {
-                SubkernelState::Finished { status: FinishStatus::Ok } |
-                SubkernelState::Running => (),
-                SubkernelState::Finished {
-                    status: FinishStatus::CommLost,
+                match unsafe { SUBKERNELS.get(&id).unwrap().state } {
+                    SubkernelState::Finished {
+                        status: FinishStatus::Ok,
+                    }
+                    | SubkernelState::Running => (),
+                    SubkernelState::Finished {
+                        status: FinishStatus::CommLost,
                     } => return Err(Error::SubkernelFinished),
-                _ => return Err(Error::IncorrectState)
+                    _ => return Err(Error::IncorrectState),
+                }
             }
-        }
             is_subkernel
         };
         let max_time = clock::get_ms() + timeout as u64;
@@ -439,10 +552,14 @@ pub mod subkernel {
                 }
             }
             if is_subkernel {
-            match unsafe { SUBKERNELS.get(&id).unwrap().state } {
-                SubkernelState::Finished { status: FinishStatus::CommLost } | 
-                    SubkernelState::Finished { status: FinishStatus::Exception(_) }  => return Ok(None),
-                _ => ()
+                match unsafe { SUBKERNELS.get(&id).unwrap().state } {
+                    SubkernelState::Finished {
+                        status: FinishStatus::CommLost,
+                    }
+                    | SubkernelState::Finished {
+                        status: FinishStatus::Exception(_),
+                    } => return Ok(None),
+                    _ => (),
                 }
             }
             Err(())
@@ -456,7 +573,7 @@ pub mod subkernel {
                     let _lock = subkernel_mutex.lock(io)?;
                     match unsafe { SUBKERNELS.get(&id).unwrap().state } {
                         SubkernelState::Finished { .. } => Err(Error::SubkernelFinished),
-                        _ => Err(Error::IncorrectState)
+                        _ => Err(Error::IncorrectState),
                     }
                 }
             }
@@ -464,22 +581,37 @@ pub mod subkernel {
         }
     }
 
-    pub fn message_send<'a>(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex, subkernel_mutex: &Mutex,
-        routing_table: &RoutingTable, id: u32, destination: Option<u8>, count: u8, tag: &'a [u8], message: *const *const ()
+    pub fn message_send<'a>(
+        io: &Io,
+        aux_mutex: &Mutex,
+        ddma_mutex: &Mutex,
+        subkernel_mutex: &Mutex,
+        routing_table: &RoutingTable,
+        id: u32,
+        destination: Option<u8>,
+        count: u8,
+        tag: &'a [u8],
+        message: *const *const (),
     ) -> Result<(), Error> {
         let mut writer = Cursor::new(Vec::new());
         // reuse rpc code for sending arbitrary data
         rpc::send_args(&mut writer, 0, tag, message, false)?;
         // skip service tag, but overwrite first byte with tag count
         let destination = destination.unwrap_or_else(|| {
-                let _lock = subkernel_mutex.lock(io).unwrap();
-                unsafe { SUBKERNELS.get(&id).unwrap().destination }
-            }
-        );
+            let _lock = subkernel_mutex.lock(io).unwrap();
+            unsafe { SUBKERNELS.get(&id).unwrap().destination }
+        });
         let data = &mut writer.into_inner()[3..];
         data[0] = count;
         Ok(drtio::subkernel_send_message(
-            io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, id, destination, data
+            io,
+            aux_mutex,
+            ddma_mutex,
+            subkernel_mutex,
+            routing_table,
+            id,
+            destination,
+            data,
         )?)
     }
 }

--- a/artiq/firmware/runtime/session.rs
+++ b/artiq/firmware/runtime/session.rs
@@ -1,34 +1,41 @@
-use core::{mem, str, cell::{Cell, RefCell}, fmt::Write as FmtWrite};
-use alloc::{vec::Vec, string::{String, ToString}};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use byteorder::{ByteOrder, NativeEndian};
+use core::{
+    cell::{Cell, RefCell},
+    fmt::Write as FmtWrite,
+    mem, str,
+};
 use cslice::CSlice;
 #[cfg(has_drtio)]
 use tar_no_std::TarArchiveRef;
 
+use board_artiq::drtio_routing;
+use board_misoc::{cache, config, ident};
+use cache::Cache;
 use dyld::elf;
-use io::{Read, Write, Error as IoError};
 #[cfg(has_drtio)]
 use io::Cursor;
-use board_misoc::{ident, cache, config};
-use {mailbox, rpc_queue, kernel};
-use urc::Urc;
-use sched::{ThreadHandle, Io, Mutex, TcpListener, TcpStream, Error as SchedError};
-use rtio_clocking;
-use rtio_dma::Manager as DmaManager;
-#[cfg(has_drtio)]
-use rtio_dma::remote_dma;
+use io::{Error as IoError, Read, Write};
+use kern_hwreq;
 #[cfg(has_drtio)]
 use kernel::{subkernel, subkernel::Error as SubkernelError};
+use rtio_clocking;
+#[cfg(has_drtio)]
+use rtio_dma::remote_dma;
+use rtio_dma::Manager as DmaManager;
 #[cfg(has_drtio)]
 use rtio_mgt::drtio;
 use rtio_mgt::get_async_errors;
-use cache::Cache;
-use kern_hwreq;
-use board_artiq::drtio_routing;
+use sched::{Error as SchedError, Io, Mutex, TcpListener, TcpStream, ThreadHandle};
+use urc::Urc;
+use {kernel, mailbox, rpc_queue};
 
+use kernel_proto as kern;
 use rpc_proto as rpc;
 use session_proto as host;
-use kernel_proto as kern;
 
 #[derive(Fail, Debug)]
 pub enum Error<T> {
@@ -131,7 +138,7 @@ macro_rules! unexpected {
 struct Congress {
     cache: Cache,
     dma_manager: DmaManager,
-    finished_cleanly: Cell<bool>
+    finished_cleanly: Cell<bool>,
 }
 
 impl Congress {
@@ -139,7 +146,7 @@ impl Congress {
         Congress {
             cache: Cache::new(),
             dma_manager: DmaManager::new(),
-            finished_cleanly: Cell::new(true)
+            finished_cleanly: Cell::new(true),
         }
     }
 }
@@ -149,7 +156,7 @@ enum KernelState {
     Absent,
     Loaded,
     Running,
-    RpcWait
+    RpcWait,
 }
 
 // Per-connection state
@@ -157,7 +164,7 @@ enum KernelState {
 struct Session<'a> {
     congress: &'a mut Congress,
     kernel_state: KernelState,
-    log_buffer: String
+    log_buffer: String,
 }
 
 impl<'a> Session<'a> {
@@ -165,14 +172,14 @@ impl<'a> Session<'a> {
         Session {
             congress: congress,
             kernel_state: KernelState::Absent,
-            log_buffer: String::new()
+            log_buffer: String::new(),
         }
     }
 
     fn running(&self) -> bool {
         match self.kernel_state {
-            KernelState::Absent  | KernelState::Loaded  => false,
-            KernelState::Running | KernelState::RpcWait => true
+            KernelState::Absent | KernelState::Loaded => false,
+            KernelState::Running | KernelState::RpcWait => true,
         }
     }
 
@@ -193,20 +200,28 @@ impl<'a> Drop for Session<'a> {
 }
 
 fn host_read<R>(reader: &mut R) -> Result<host::Request, Error<R::ReadError>>
-    where R: Read + ?Sized
+where
+    R: Read + ?Sized,
 {
     let request = host::Request::read_from(reader)?;
     match &request {
         &host::Request::LoadKernel(_) => debug!("comm<-host LoadLibrary(...)"),
-        &host::Request::UploadSubkernel { id, destination, kernel: _} => debug!(
-            "comm<-host UploadSubkernel(id: {}, destination: {}, ...)", id, destination),
-        _ => debug!("comm<-host {:?}", request)
+        &host::Request::UploadSubkernel {
+            id,
+            destination,
+            kernel: _,
+        } => debug!(
+            "comm<-host UploadSubkernel(id: {}, destination: {}, ...)",
+            id, destination
+        ),
+        _ => debug!("comm<-host {:?}", request),
     }
     Ok(request)
 }
 
 fn host_write<W>(writer: &mut W, reply: host::Reply) -> Result<(), IoError<W::WriteError>>
-    where W: Write + ?Sized
+where
+    W: Write + ?Sized,
 {
     debug!("comm->host {:?}", reply);
     reply.write_to(writer)
@@ -215,25 +230,37 @@ fn host_write<W>(writer: &mut W, reply: host::Reply) -> Result<(), IoError<W::Wr
 pub fn kern_send(io: &Io, request: &kern::Message) -> Result<(), Error<SchedError>> {
     match request {
         &kern::LoadRequest(_) => debug!("comm->kern LoadRequest(...)"),
-        &kern::DmaRetrieveReply { trace, duration, uses_ddma } => {
+        &kern::DmaRetrieveReply {
+            trace,
+            duration,
+            uses_ddma,
+        } => {
             if trace.map(|data| data.len() > 100).unwrap_or(false) {
-                debug!("comm->kern DmaRetrieveReply {{ trace: ..., duration: {:?}, uses_ddma: {} }}", duration, uses_ddma)
+                debug!(
+                    "comm->kern DmaRetrieveReply {{ trace: ..., duration: {:?}, uses_ddma: {} }}",
+                    duration, uses_ddma
+                )
             } else {
                 debug!("comm->kern {:?}", request)
             }
         }
-        _ => debug!("comm->kern {:?}", request)
+        _ => debug!("comm->kern {:?}", request),
     }
     unsafe { mailbox::send(request as *const _ as usize) }
     Ok(io.until(mailbox::acknowledged)?)
 }
 
 fn kern_recv_notrace<R, F>(io: &Io, f: F) -> Result<R, Error<SchedError>>
-        where F: FnOnce(&kern::Message) -> Result<R, Error<SchedError>> {
+where
+    F: FnOnce(&kern::Message) -> Result<R, Error<SchedError>>,
+{
     let mut msg_ptr = 0;
-    io.until(|| { msg_ptr = mailbox::receive(); msg_ptr != 0 })?;
+    io.until(|| {
+        msg_ptr = mailbox::receive();
+        msg_ptr != 0
+    })?;
     if !kernel::validate(msg_ptr) {
-        return Err(Error::InvalidPointer(msg_ptr))
+        return Err(Error::InvalidPointer(msg_ptr));
     }
 
     f(unsafe { &*(msg_ptr as *const kern::Message) })
@@ -250,13 +277,15 @@ fn kern_recv_dotrace(reply: &kern::Message) {
                 debug!("comm<-kern {:?}", reply)
             }
         }
-        _ => debug!("comm<-kern {:?}", reply)
+        _ => debug!("comm<-kern {:?}", reply),
     }
 }
 
 #[inline(always)]
 fn kern_recv<R, F>(io: &Io, f: F) -> Result<R, Error<SchedError>>
-        where F: FnOnce(&kern::Message) -> Result<R, Error<SchedError>> {
+where
+    F: FnOnce(&kern::Message) -> Result<R, Error<SchedError>>,
+{
     kern_recv_notrace(io, |reply| {
         kern_recv_dotrace(reply);
         f(reply)
@@ -268,8 +297,11 @@ pub fn kern_acknowledge() -> Result<(), Error<SchedError>> {
     Ok(())
 }
 
-unsafe fn kern_load(io: &Io, session: &mut Session, library: &[u8])
-                   -> Result<(), Error<SchedError>> {
+unsafe fn kern_load(
+    io: &Io,
+    session: &mut Session,
+    library: &[u8],
+) -> Result<(), Error<SchedError>> {
     if session.running() {
         unexpected!("attempted to load a new kernel while a kernel was running")
     }
@@ -277,19 +309,16 @@ unsafe fn kern_load(io: &Io, session: &mut Session, library: &[u8])
     kernel::start();
 
     kern_send(io, &kern::LoadRequest(&library))?;
-    kern_recv(io, |reply| {
-        match reply {
-            kern::LoadReply(Ok(())) => {
-                session.kernel_state = KernelState::Loaded;
-                Ok(())
-            }
-            kern::LoadReply(Err(error)) => {
-                kernel::stop();
-                Err(Error::Load(format!("{}", error)))
-            }
-            other =>
-                unexpected!("unexpected kernel CPU reply to load request: {:?}", other)
+    kern_recv(io, |reply| match reply {
+        kern::LoadReply(Ok(())) => {
+            session.kernel_state = KernelState::Loaded;
+            Ok(())
         }
+        kern::LoadReply(Err(error)) => {
+            kernel::stop();
+            Err(Error::Load(format!("{}", error)))
+        }
+        other => unexpected!("unexpected kernel CPU reply to load request: {:?}", other),
     })
 }
 
@@ -303,15 +332,22 @@ fn kern_run(session: &mut Session) -> Result<(), Error<SchedError>> {
     kern_acknowledge()
 }
 
-
-fn process_flash_kernel(io: &Io, _aux_mutex: &Mutex, _subkernel_mutex: &Mutex, _ddma_mutex: &Mutex,
-                        _routing_table: &drtio_routing::RoutingTable,
-                        _up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
-                        session: &mut Session, kernel: &[u8]
+fn process_flash_kernel(
+    io: &Io,
+    _aux_mutex: &Mutex,
+    _subkernel_mutex: &Mutex,
+    _ddma_mutex: &Mutex,
+    _routing_table: &drtio_routing::RoutingTable,
+    _up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
+    session: &mut Session,
+    kernel: &[u8],
 ) -> Result<(), Error<SchedError>> {
     // handle ELF and TAR files
-    if kernel[0] == elf::ELFMAG0 && kernel[1] == elf::ELFMAG1 &&
-       kernel[2] == elf::ELFMAG2 && kernel[3] == elf::ELFMAG3 {
+    if kernel[0] == elf::ELFMAG0
+        && kernel[1] == elf::ELFMAG1
+        && kernel[2] == elf::ELFMAG2
+        && kernel[3] == elf::ELFMAG3
+    {
         // assume ELF file, proceed as before
         unsafe {
             // make a copy as kernel CPU cannot read SPI directly
@@ -319,7 +355,7 @@ fn process_flash_kernel(io: &Io, _aux_mutex: &Mutex, _subkernel_mutex: &Mutex, _
         }
     } else {
         #[cfg(has_drtio)]
-        {  
+        {
             let archive = TarArchiveRef::new(kernel);
             let entries = archive.entries();
             let mut main_lib: Option<&[u8]> = None;
@@ -331,11 +367,14 @@ fn process_flash_kernel(io: &Io, _aux_mutex: &Mutex, _subkernel_mutex: &Mutex, _
                     // "<subkernel id> <destination>.elf"
                     let filename = entry.filename();
                     let mut iter = filename.as_str().split_whitespace();
-                    let sid: u32 = iter.next().unwrap()
-                                    .parse().unwrap();
-                    let dest: u8 = iter.next().unwrap()
-                                    .strip_suffix(".elf").unwrap()
-                                    .parse().unwrap();
+                    let sid: u32 = iter.next().unwrap().parse().unwrap();
+                    let dest: u8 = iter
+                        .next()
+                        .unwrap()
+                        .strip_suffix(".elf")
+                        .unwrap()
+                        .parse()
+                        .unwrap();
                     let up = {
                         let up_destinations = _up_destinations.borrow();
                         up_destinations[dest as usize]
@@ -343,15 +382,20 @@ fn process_flash_kernel(io: &Io, _aux_mutex: &Mutex, _subkernel_mutex: &Mutex, _
                     if up {
                         let subkernel_lib = entry.data().to_vec();
                         subkernel::add_subkernel(io, _subkernel_mutex, sid, dest, subkernel_lib)?;
-                        subkernel::upload(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, sid)?;
+                        subkernel::upload(
+                            io,
+                            _aux_mutex,
+                            _ddma_mutex,
+                            _subkernel_mutex,
+                            _routing_table,
+                            sid,
+                        )?;
                     } else {
                         return Err(Error::DestinationDown);
                     }
                 }
             }
-            unsafe {
-                kern_load(io, session, Vec::from(main_lib.unwrap()).as_ref())
-            }
+            unsafe { kern_load(io, session, Vec::from(main_lib.unwrap()).as_ref()) }
         }
         #[cfg(not(has_drtio))]
         {
@@ -360,90 +404,104 @@ fn process_flash_kernel(io: &Io, _aux_mutex: &Mutex, _subkernel_mutex: &Mutex, _
     }
 }
 
-fn process_host_message(io: &Io, _aux_mutex: &Mutex, _ddma_mutex: &Mutex, _subkernel_mutex: &Mutex,
-                        _routing_table: &drtio_routing::RoutingTable, stream: &mut TcpStream,
-                        session: &mut Session) -> Result<(), Error<SchedError>> {
+fn process_host_message(
+    io: &Io,
+    _aux_mutex: &Mutex,
+    _ddma_mutex: &Mutex,
+    _subkernel_mutex: &Mutex,
+    _routing_table: &drtio_routing::RoutingTable,
+    stream: &mut TcpStream,
+    session: &mut Session,
+) -> Result<(), Error<SchedError>> {
     match host_read(stream)? {
         host::Request::SystemInfo => {
-            host_write(stream, host::Reply::SystemInfo {
-                ident: ident::read(&mut [0; 64]),
-                finished_cleanly: session.congress.finished_cleanly.get()
-            })?;
+            host_write(
+                stream,
+                host::Reply::SystemInfo {
+                    ident: ident::read(&mut [0; 64]),
+                    finished_cleanly: session.congress.finished_cleanly.get(),
+                },
+            )?;
             session.congress.finished_cleanly.set(true)
         }
 
-        host::Request::LoadKernel(kernel) => {
-            match unsafe { kern_load(io, session, &kernel) } {
-                Ok(()) => host_write(stream, host::Reply::LoadCompleted)?,
-                Err(error) => {
-                    let mut description = String::new();
-                    write!(&mut description, "{}", error).unwrap();
-                    host_write(stream, host::Reply::LoadFailed(&description))?;
-                    kern_acknowledge()?;
-                }
+        host::Request::LoadKernel(kernel) => match unsafe { kern_load(io, session, &kernel) } {
+            Ok(()) => host_write(stream, host::Reply::LoadCompleted)?,
+            Err(error) => {
+                let mut description = String::new();
+                write!(&mut description, "{}", error).unwrap();
+                host_write(stream, host::Reply::LoadFailed(&description))?;
+                kern_acknowledge()?;
             }
         },
-        host::Request::RunKernel =>
-            match kern_run(session) {
-                Ok(()) => (),
-                Err(_) => host_write(stream, host::Reply::KernelStartupFailed)?
-            },
+        host::Request::RunKernel => match kern_run(session) {
+            Ok(()) => (),
+            Err(_) => host_write(stream, host::Reply::KernelStartupFailed)?,
+        },
 
         host::Request::RpcReply { tag } => {
             if session.kernel_state != KernelState::RpcWait {
                 unexpected!("unsolicited RPC reply")
             }
 
-            let slot = kern_recv(io, |reply| {
-                match reply {
-                    &kern::RpcRecvRequest(slot) => Ok(slot),
-                    other => unexpected!(
-                        "expected root value slot from kernel CPU, not {:?}", other)
-                }
+            let slot = kern_recv(io, |reply| match reply {
+                &kern::RpcRecvRequest(slot) => Ok(slot),
+                other => unexpected!("expected root value slot from kernel CPU, not {:?}", other),
             })?;
-            rpc::recv_return(stream, &tag, slot, &|size| -> Result<_, Error<SchedError>> {
-                if size == 0 {
-                    // Don't try to allocate zero-length values, as RpcRecvReply(0) is
-                    // used to terminate the kernel-side receive loop.
-                    return Ok(0 as *mut ())
-                }
-                kern_send(io, &kern::RpcRecvReply(Ok(size)))?;
-                Ok(kern_recv(io, |reply| {
-                    match reply {
+            rpc::recv_return(
+                stream,
+                &tag,
+                slot,
+                &|size| -> Result<_, Error<SchedError>> {
+                    if size == 0 {
+                        // Don't try to allocate zero-length values, as RpcRecvReply(0) is
+                        // used to terminate the kernel-side receive loop.
+                        return Ok(0 as *mut ());
+                    }
+                    kern_send(io, &kern::RpcRecvReply(Ok(size)))?;
+                    Ok(kern_recv(io, |reply| match reply {
                         &kern::RpcRecvRequest(slot) => Ok(slot),
                         other => unexpected!(
-                            "expected nested value slot from kernel CPU, not {:?}", other)
-                    }
-                })?)
-            })?;
+                            "expected nested value slot from kernel CPU, not {:?}",
+                            other
+                        ),
+                    })?)
+                },
+            )?;
             kern_send(io, &kern::RpcRecvReply(Ok(0)))?;
 
             session.kernel_state = KernelState::Running
         }
 
         host::Request::RpcException {
-            id, message, param, file, line, column, function
+            id,
+            message,
+            param,
+            file,
+            line,
+            column,
+            function,
         } => {
             if session.kernel_state != KernelState::RpcWait {
                 unexpected!("unsolicited RPC reply")
             }
 
-            kern_recv(io, |reply| {
-                match reply {
-                    &kern::RpcRecvRequest(_) => Ok(()),
-                    other => unexpected!(
-                        "expected (ignored) root value slot from kernel CPU, not {:?}", other)
-                }
+            kern_recv(io, |reply| match reply {
+                &kern::RpcRecvRequest(_) => Ok(()),
+                other => unexpected!(
+                    "expected (ignored) root value slot from kernel CPU, not {:?}",
+                    other
+                ),
             })?;
 
             unsafe {
                 let exn = eh::eh_artiq::Exception {
-                    id:       id,
-                    message:  CSlice::new(message as *const u8, usize::MAX),
-                    param:    param,
-                    file:     CSlice::new(file as *const u8, usize::MAX),
-                    line:     line,
-                    column:   column,
+                    id: id,
+                    message: CSlice::new(message as *const u8, usize::MAX),
+                    param: param,
+                    file: CSlice::new(file as *const u8, usize::MAX),
+                    line: line,
+                    column: column,
                     function: CSlice::new(function as *const u8, usize::MAX),
                 };
                 kern_send(io, &kern::RpcRecvReply(Err(exn)))?;
@@ -452,11 +510,22 @@ fn process_host_message(io: &Io, _aux_mutex: &Mutex, _ddma_mutex: &Mutex, _subke
             session.kernel_state = KernelState::Running
         }
 
-        host::Request::UploadSubkernel { id: _id, destination: _dest, kernel: _kernel } => {
+        host::Request::UploadSubkernel {
+            id: _id,
+            destination: _dest,
+            kernel: _kernel,
+        } => {
             #[cfg(has_drtio)]
             {
                 subkernel::add_subkernel(io, _subkernel_mutex, _id, _dest, _kernel)?;
-                match subkernel::upload(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, _id) {
+                match subkernel::upload(
+                    io,
+                    _aux_mutex,
+                    _ddma_mutex,
+                    _subkernel_mutex,
+                    _routing_table,
+                    _id,
+                ) {
                     Ok(_) => host_write(stream, host::Reply::LoadCompleted)?,
                     Err(error) => {
                         subkernel::clear_subkernels(io, _subkernel_mutex)?;
@@ -467,44 +536,64 @@ fn process_host_message(io: &Io, _aux_mutex: &Mutex, _ddma_mutex: &Mutex, _subke
                 }
             }
             #[cfg(not(has_drtio))]
-            host_write(stream, host::Reply::LoadFailed("No DRTIO on this system, subkernels are not supported"))?
+            host_write(
+                stream,
+                host::Reply::LoadFailed("No DRTIO on this system, subkernels are not supported"),
+            )?
         }
     }
 
     Ok(())
 }
 
-fn process_kern_message(io: &Io, aux_mutex: &Mutex,
-                        routing_table: &drtio_routing::RoutingTable,
-                        up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
-                        ddma_mutex: &Mutex, subkernel_mutex: &Mutex, mut stream: Option<&mut TcpStream>,
-                        session: &mut Session) -> Result<bool, Error<SchedError>> {
+fn process_kern_message(
+    io: &Io,
+    aux_mutex: &Mutex,
+    routing_table: &drtio_routing::RoutingTable,
+    up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
+    ddma_mutex: &Mutex,
+    subkernel_mutex: &Mutex,
+    mut stream: Option<&mut TcpStream>,
+    session: &mut Session,
+) -> Result<bool, Error<SchedError>> {
     kern_recv_notrace(io, |request| {
         match (request, session.kernel_state) {
-            (&kern::LoadReply(_), KernelState::Loaded) |
-            (&kern::RpcRecvRequest(_), KernelState::RpcWait) => {
+            (&kern::LoadReply(_), KernelState::Loaded)
+            | (&kern::RpcRecvRequest(_), KernelState::RpcWait) => {
                 // We're standing by; ignore the message.
-                return Ok(false)
+                return Ok(false);
             }
             (_, KernelState::Running) => (),
             _ => {
-                unexpected!("unexpected request {:?} from kernel CPU in {:?} state",
-                            request, session.kernel_state)
+                unexpected!(
+                    "unexpected request {:?} from kernel CPU in {:?} state",
+                    request,
+                    session.kernel_state
+                )
             }
         }
 
         kern_recv_dotrace(request);
 
-        if kern_hwreq::process_kern_hwreq(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, up_destinations, request)? {
-            return Ok(false)
+        if kern_hwreq::process_kern_hwreq(
+            io,
+            aux_mutex,
+            ddma_mutex,
+            subkernel_mutex,
+            routing_table,
+            up_destinations,
+            request,
+        )? {
+            return Ok(false);
         }
 
         match request {
             &kern::Log(args) => {
                 use core::fmt::Write;
-                session.log_buffer
-                       .write_fmt(args)
-                       .unwrap_or_else(|_| warn!("cannot append to session log buffer"));
+                session
+                    .log_buffer
+                    .write_fmt(args)
+                    .unwrap_or_else(|_| warn!("cannot append to session log buffer"));
                 session.flush_log_buffer();
                 kern_acknowledge()
             }
@@ -519,7 +608,14 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                 if let Some(_id) = session.congress.dma_manager.record_start(name) {
                     // replace the record
                     #[cfg(has_drtio)]
-                    remote_dma::erase(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, _id)?;
+                    remote_dma::erase(
+                        io,
+                        aux_mutex,
+                        ddma_mutex,
+                        subkernel_mutex,
+                        routing_table,
+                        _id,
+                    )?;
                 }
                 kern_acknowledge()
             }
@@ -527,11 +623,26 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                 session.congress.dma_manager.record_append(data);
                 kern_acknowledge()
             }
-            &kern::DmaRecordStop { duration, enable_ddma } => {
-                let _id = session.congress.dma_manager.record_stop(duration, enable_ddma, io, ddma_mutex)?;
+            &kern::DmaRecordStop {
+                duration,
+                enable_ddma,
+            } => {
+                let _id = session.congress.dma_manager.record_stop(
+                    duration,
+                    enable_ddma,
+                    io,
+                    ddma_mutex,
+                )?;
                 #[cfg(has_drtio)]
                 if enable_ddma {
-                    remote_dma::upload_traces(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, _id)?;
+                    remote_dma::upload_traces(
+                        io,
+                        aux_mutex,
+                        ddma_mutex,
+                        subkernel_mutex,
+                        routing_table,
+                        _id,
+                    )?;
                 }
                 cache::flush_l2_cache();
                 kern_acknowledge()
@@ -539,60 +650,102 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
             &kern::DmaEraseRequest { name } => {
                 #[cfg(has_drtio)]
                 if let Some(id) = session.congress.dma_manager.get_id(name) {
-                    remote_dma::erase(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, *id)?;
+                    remote_dma::erase(
+                        io,
+                        aux_mutex,
+                        ddma_mutex,
+                        subkernel_mutex,
+                        routing_table,
+                        *id,
+                    )?;
                 }
                 session.congress.dma_manager.erase(name);
                 kern_acknowledge()
             }
             &kern::DmaRetrieveRequest { name } => {
-                session.congress.dma_manager.with_trace(name, |trace, duration| {
-                    #[cfg(has_drtio)]
-                    let uses_ddma = match trace {
-                        Some(trace) => remote_dma::has_remote_traces(io, aux_mutex, trace.as_ptr() as u32)?,
-                        None => false
-                    };
-                    #[cfg(not(has_drtio))]
-                    let uses_ddma = false;
-                    kern_send(io, &kern::DmaRetrieveReply {
-                        trace:    trace,
-                        duration: duration,
-                        uses_ddma: uses_ddma,
+                session
+                    .congress
+                    .dma_manager
+                    .with_trace(name, |trace, duration| {
+                        #[cfg(has_drtio)]
+                        let uses_ddma = match trace {
+                            Some(trace) => {
+                                remote_dma::has_remote_traces(io, aux_mutex, trace.as_ptr() as u32)?
+                            }
+                            None => false,
+                        };
+                        #[cfg(not(has_drtio))]
+                        let uses_ddma = false;
+                        kern_send(
+                            io,
+                            &kern::DmaRetrieveReply {
+                                trace: trace,
+                                duration: duration,
+                                uses_ddma: uses_ddma,
+                            },
+                        )
                     })
-                })
             }
-            &kern::DmaStartRemoteRequest { id: _id, timestamp: _timestamp } => {
+            &kern::DmaStartRemoteRequest {
+                id: _id,
+                timestamp: _timestamp,
+            } => {
                 #[cfg(has_drtio)]
-                remote_dma::playback(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, _id as u32, _timestamp as u64)?;
+                remote_dma::playback(
+                    io,
+                    aux_mutex,
+                    ddma_mutex,
+                    subkernel_mutex,
+                    routing_table,
+                    _id as u32,
+                    _timestamp as u64,
+                )?;
                 kern_acknowledge()
             }
             &kern::DmaAwaitRemoteRequest { id: _id } => {
                 #[cfg(has_drtio)]
                 let reply = match remote_dma::await_done(io, ddma_mutex, _id as u32, 10_000) {
-                    Ok(remote_dma::RemoteState::PlaybackEnded { error, channel, timestamp }) =>
-                        kern::DmaAwaitRemoteReply {
-                            timeout: false,
-                            error: error,
-                            channel: channel,
-                            timestamp: timestamp
-                        },
-                    _ => kern::DmaAwaitRemoteReply { timeout: true, error: 0, channel: 0, timestamp: 0},
+                    Ok(remote_dma::RemoteState::PlaybackEnded {
+                        error,
+                        channel,
+                        timestamp,
+                    }) => kern::DmaAwaitRemoteReply {
+                        timeout: false,
+                        error: error,
+                        channel: channel,
+                        timestamp: timestamp,
+                    },
+                    _ => kern::DmaAwaitRemoteReply {
+                        timeout: true,
+                        error: 0,
+                        channel: 0,
+                        timestamp: 0,
+                    },
                 };
                 #[cfg(not(has_drtio))]
-                let reply = kern::DmaAwaitRemoteReply { timeout: false, error: 0, channel: 0, timestamp: 0};
+                let reply = kern::DmaAwaitRemoteReply {
+                    timeout: false,
+                    error: 0,
+                    channel: 0,
+                    timestamp: 0,
+                };
                 kern_send(io, &reply)
             }
 
-            &kern::RpcSend { async, service, tag, data } => {
-                match stream {
-                    None => unexpected!("unexpected RPC in flash kernel"),
-                    Some(ref mut stream) => {
-                        host_write(stream, host::Reply::RpcRequest { async: async })?;
-                        rpc::send_args(stream, service, tag, data, true)?;
-                        if !async {
-                            session.kernel_state = KernelState::RpcWait
-                        }
-                        kern_acknowledge()
+            &kern::RpcSend {
+                async,
+                service,
+                tag,
+                data,
+            } => match stream {
+                None => unexpected!("unexpected RPC in flash kernel"),
+                Some(ref mut stream) => {
+                    host_write(stream, host::Reply::RpcRequest { async: async })?;
+                    rpc::send_args(stream, service, tag, data, true)?;
+                    if !async {
+                        session.kernel_state = KernelState::RpcWait
                     }
+                    kern_acknowledge()
                 }
             },
             &kern::RpcFlush => {
@@ -600,20 +753,28 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                 // We do not need to do anything here because of how the main loop is
                 // structured.
                 kern_acknowledge()
-            },
+            }
 
             &kern::CacheGetRequest { key } => {
                 let value = session.congress.cache.get(key);
-                kern_send(io, &kern::CacheGetReply {
-                    // Zing! This transmute is only safe because we dynamically track
-                    // whether the kernel has borrowed any values from the cache.
-                    value: unsafe { mem::transmute(value) }
-                })
+                kern_send(
+                    io,
+                    &kern::CacheGetReply {
+                        // Zing! This transmute is only safe because we dynamically track
+                        // whether the kernel has borrowed any values from the cache.
+                        value: unsafe { mem::transmute(value) },
+                    },
+                )
             }
 
             &kern::CachePutRequest { key, value } => {
                 let succeeded = session.congress.cache.put(key, value).is_ok();
-                kern_send(io, &kern::CachePutReply { succeeded: succeeded })
+                kern_send(
+                    io,
+                    &kern::CachePutReply {
+                        succeeded: succeeded,
+                    },
+                )
             }
 
             &kern::RunFinished => {
@@ -625,16 +786,19 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
 
                 match stream {
                     None => return Ok(true),
-                    Some(ref mut stream) =>
-                        host_write(stream, host::Reply::KernelFinished {
-                            async_errors: unsafe { get_async_errors() }
-                        }).map_err(|e| e.into())
+                    Some(ref mut stream) => host_write(
+                        stream,
+                        host::Reply::KernelFinished {
+                            async_errors: unsafe { get_async_errors() },
+                        },
+                    )
+                    .map_err(|e| e.into()),
                 }
             }
             &kern::RunException {
                 exceptions,
                 stack_pointers,
-                backtrace
+                backtrace,
             } => {
                 unsafe { kernel::stop() }
                 session.kernel_state = KernelState::Absent;
@@ -648,86 +812,152 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                         for exception in exceptions {
                             error!("{:?}", exception.unwrap());
                         }
-                        return Ok(true)
-                    },
-                    Some(ref mut stream) => {
-                        host_write(stream, host::Reply::KernelException {
+                        return Ok(true);
+                    }
+                    Some(ref mut stream) => host_write(
+                        stream,
+                        host::Reply::KernelException {
                             exceptions: exceptions,
                             stack_pointers: stack_pointers,
                             backtrace: backtrace,
-                            async_errors: unsafe { get_async_errors() }
-                        }).map_err(|e| e.into())
-                    }
+                            async_errors: unsafe { get_async_errors() },
+                        },
+                    )
+                    .map_err(|e| e.into()),
                 }
             }
             #[cfg(has_drtio)]
-            &kern::SubkernelLoadRunRequest { id, destination: _, run, timestamp } => {
+            &kern::SubkernelLoadRunRequest {
+                id,
+                destination: _,
+                run,
+                timestamp,
+            } => {
                 let succeeded = match subkernel::load(
-                    io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, id, run, timestamp) {
-                        Ok(()) => true,
-                        Err(e) => { error!("Error loading subkernel: {}", e); false }
-                    };
-                kern_send(io, &kern::SubkernelLoadRunReply { succeeded: succeeded })
+                    io,
+                    aux_mutex,
+                    ddma_mutex,
+                    subkernel_mutex,
+                    routing_table,
+                    id,
+                    run,
+                    timestamp,
+                ) {
+                    Ok(()) => true,
+                    Err(e) => {
+                        error!("Error loading subkernel: {}", e);
+                        false
+                    }
+                };
+                kern_send(
+                    io,
+                    &kern::SubkernelLoadRunReply {
+                        succeeded: succeeded,
+                    },
+                )
             }
             #[cfg(has_drtio)]
-            &kern::SubkernelAwaitFinishRequest{ id, timeout } => {
-                let res = subkernel::await_finish(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table,
-                    id, timeout);
+            &kern::SubkernelAwaitFinishRequest { id, timeout } => {
+                let res = subkernel::await_finish(
+                    io,
+                    aux_mutex,
+                    ddma_mutex,
+                    subkernel_mutex,
+                    routing_table,
+                    id,
+                    timeout,
+                );
                 let response = match res {
                     Ok(ref res) => {
-                            if res.comm_lost {
-                                kern::SubkernelError(kern::SubkernelStatus::CommLost)
-                            } else if let Some(raw_exception) = &res.exception {
-                                let exception = subkernel::read_exception(raw_exception);
-                                if let Ok(exception) = exception {
-                                    kern::SubkernelError(kern::SubkernelStatus::Exception(exception))
-                                } else {
-                                    kern::SubkernelError(kern::SubkernelStatus::OtherError)
-                                }
+                        if res.comm_lost {
+                            kern::SubkernelError(kern::SubkernelStatus::CommLost)
+                        } else if let Some(raw_exception) = &res.exception {
+                            let exception = subkernel::read_exception(raw_exception);
+                            if let Ok(exception) = exception {
+                                kern::SubkernelError(kern::SubkernelStatus::Exception(exception))
                             } else {
-                                kern::SubkernelAwaitFinishReply
+                                kern::SubkernelError(kern::SubkernelStatus::OtherError)
                             }
-                        },
-                    Err(SubkernelError::Timeout) => kern::SubkernelError(kern::SubkernelStatus::Timeout),
-                    Err(SubkernelError::IncorrectState) => kern::SubkernelError(kern::SubkernelStatus::IncorrectState),
-                    Err(_) => kern::SubkernelError(kern::SubkernelStatus::OtherError)
+                        } else {
+                            kern::SubkernelAwaitFinishReply
+                        }
+                    }
+                    Err(SubkernelError::Timeout) => {
+                        kern::SubkernelError(kern::SubkernelStatus::Timeout)
+                    }
+                    Err(SubkernelError::IncorrectState) => {
+                        kern::SubkernelError(kern::SubkernelStatus::IncorrectState)
+                    }
+                    Err(_) => kern::SubkernelError(kern::SubkernelStatus::OtherError),
                 };
                 kern_send(io, &response)
             }
             #[cfg(has_drtio)]
-            &kern::SubkernelMsgSend { id, destination, count, tag, data } => {
-                subkernel::message_send(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, id, destination, count, tag, data)?;
+            &kern::SubkernelMsgSend {
+                id,
+                destination,
+                count,
+                tag,
+                data,
+            } => {
+                subkernel::message_send(
+                    io,
+                    aux_mutex,
+                    ddma_mutex,
+                    subkernel_mutex,
+                    routing_table,
+                    id,
+                    destination,
+                    count,
+                    tag,
+                    data,
+                )?;
                 kern_acknowledge()
             }
             #[cfg(has_drtio)]
             &kern::SubkernelMsgRecvRequest { id, timeout, tags } => {
-                let message_received = subkernel::message_await(io, subkernel_mutex, id as u32, timeout);
+                let message_received =
+                    subkernel::message_await(io, subkernel_mutex, id as u32, timeout);
                 if let Err(SubkernelError::SubkernelFinished) = message_received {
-                    let res = subkernel::retrieve_finish_status(io, aux_mutex, ddma_mutex, subkernel_mutex,
-                        routing_table, id as u32)?;
+                    let res = subkernel::retrieve_finish_status(
+                        io,
+                        aux_mutex,
+                        ddma_mutex,
+                        subkernel_mutex,
+                        routing_table,
+                        id as u32,
+                    )?;
                     if res.comm_lost {
-                        kern_send(io, 
-                            &kern::SubkernelError(kern::SubkernelStatus::CommLost))?;
+                        kern_send(io, &kern::SubkernelError(kern::SubkernelStatus::CommLost))?;
                     } else if let Some(raw_exception) = &res.exception {
                         let exception = subkernel::read_exception(raw_exception);
                         if let Ok(exception) = exception {
-                            kern_send(io,
-                                &kern::SubkernelError(kern::SubkernelStatus::Exception(exception)))?;
+                            kern_send(
+                                io,
+                                &kern::SubkernelError(kern::SubkernelStatus::Exception(exception)),
+                            )?;
                         } else {
-                            kern_send(io,
-                                &kern::SubkernelError(kern::SubkernelStatus::OtherError))?;
+                            kern_send(
+                                io,
+                                &kern::SubkernelError(kern::SubkernelStatus::OtherError),
+                            )?;
                         }
                     } else {
-                        kern_send(io,
-                            &kern::SubkernelError(kern::SubkernelStatus::OtherError))?;
+                        kern_send(io, &kern::SubkernelError(kern::SubkernelStatus::OtherError))?;
                     }
                 } else {
                     let message = match message_received {
-                        Ok(ref message) => kern::SubkernelMsgRecvReply { count: message.count },
-                        Err(SubkernelError::Timeout) => kern::SubkernelError(kern::SubkernelStatus::Timeout),
-                        Err(SubkernelError::IncorrectState) => kern::SubkernelError(kern::SubkernelStatus::IncorrectState),
+                        Ok(ref message) => kern::SubkernelMsgRecvReply {
+                            count: message.count,
+                        },
+                        Err(SubkernelError::Timeout) => {
+                            kern::SubkernelError(kern::SubkernelStatus::Timeout)
+                        }
+                        Err(SubkernelError::IncorrectState) => {
+                            kern::SubkernelError(kern::SubkernelStatus::IncorrectState)
+                        }
                         Err(SubkernelError::SubkernelFinished) => unreachable!(), // taken care of above
-                        Err(_) => kern::SubkernelError(kern::SubkernelStatus::OtherError)
+                        Err(_) => kern::SubkernelError(kern::SubkernelStatus::OtherError),
                     };
                     kern_send(io, &message)?;
                     if let Ok(message) = message_received {
@@ -737,26 +967,31 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                         let mut i = 0;
                         loop {
                             // kernel has to consume all arguments in the whole message
-                            let slot = kern_recv(io, |reply| {
-                                match reply {
-                                    &kern::RpcRecvRequest(slot) => Ok(slot),
-                                    other => unexpected!(
-                                        "expected root value slot from kernel CPU, not {:?}", other)
-                                }
+                            let slot = kern_recv(io, |reply| match reply {
+                                &kern::RpcRecvRequest(slot) => Ok(slot),
+                                other => unexpected!(
+                                    "expected root value slot from kernel CPU, not {:?}",
+                                    other
+                                ),
                             })?;
-                            let res = rpc::recv_return(&mut reader, current_tags, slot, &|size| -> Result<_, Error<SchedError>> {
-                                if size == 0 {
-                                    return Ok(0 as *mut ())
-                                }
-                                kern_send(io, &kern::RpcRecvReply(Ok(size)))?;
-                                Ok(kern_recv(io, |reply| {
-                                    match reply {
+                            let res = rpc::recv_return(
+                                &mut reader,
+                                current_tags,
+                                slot,
+                                &|size| -> Result<_, Error<SchedError>> {
+                                    if size == 0 {
+                                        return Ok(0 as *mut ());
+                                    }
+                                    kern_send(io, &kern::RpcRecvReply(Ok(size)))?;
+                                    Ok(kern_recv(io, |reply| match reply {
                                         &kern::RpcRecvRequest(slot) => Ok(slot),
                                         other => unexpected!(
-                                            "expected nested value slot from kernel CPU, not {:?}", other)
-                                    }
-                                })?)
-                            });
+                                            "expected nested value slot from kernel CPU, not {:?}",
+                                            other
+                                        ),
+                                    })?)
+                                },
+                            );
                             match res {
                                 Ok(new_tags) => {
                                     kern_send(io, &kern::RpcRecvReply(Ok(0)))?;
@@ -768,23 +1003,26 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                                         // should be done by then
                                         break;
                                     }
-                                },
-                                Err(_) => unexpected!("expected valid subkernel message data")
+                                }
+                                Err(_) => unexpected!("expected valid subkernel message data"),
                             };
                         }
                     }
                     // if timed out, no data has been received, exception should be raised by kernel
                 }
                 Ok(())
-            },
+            }
 
-            request => unexpected!("unexpected request {:?} from kernel CPU", request)
-        }.and(Ok(false))
+            request => unexpected!("unexpected request {:?} from kernel CPU", request),
+        }
+        .and(Ok(false))
     })
 }
 
-fn process_kern_queued_rpc(stream: &mut TcpStream,
-                           _session: &mut Session) -> Result<(), Error<SchedError>> {
+fn process_kern_queued_rpc(
+    stream: &mut TcpStream,
+    _session: &mut Session,
+) -> Result<(), Error<SchedError>> {
     rpc_queue::dequeue(|slice| {
         debug!("comm<-kern (async RPC)");
         let length = NativeEndian::read_u32(slice) as usize;
@@ -795,22 +1033,33 @@ fn process_kern_queued_rpc(stream: &mut TcpStream,
     })
 }
 
-fn host_kernel_worker(io: &Io, aux_mutex: &Mutex,
-                      routing_table: &drtio_routing::RoutingTable,
-                      up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
-                      ddma_mutex: &Mutex, subkernel_mutex: &Mutex,
-                      stream: &mut TcpStream,
-                      congress: &mut Congress) -> Result<(), Error<SchedError>> {
+fn host_kernel_worker(
+    io: &Io,
+    aux_mutex: &Mutex,
+    routing_table: &drtio_routing::RoutingTable,
+    up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
+    ddma_mutex: &Mutex,
+    subkernel_mutex: &Mutex,
+    stream: &mut TcpStream,
+    congress: &mut Congress,
+) -> Result<(), Error<SchedError>> {
     let mut session = Session::new(congress);
     #[cfg(has_drtio)]
     subkernel::clear_subkernels(&io, &subkernel_mutex)?;
 
     loop {
         if stream.can_recv() {
-            process_host_message(io, aux_mutex, ddma_mutex, subkernel_mutex,
-                routing_table, stream, &mut session)?
+            process_host_message(
+                io,
+                aux_mutex,
+                ddma_mutex,
+                subkernel_mutex,
+                routing_table,
+                stream,
+                &mut session,
+            )?
         } else if !stream.may_recv() {
-            return Ok(())
+            return Ok(());
         }
 
         while !rpc_queue::empty() {
@@ -818,16 +1067,22 @@ fn host_kernel_worker(io: &Io, aux_mutex: &Mutex,
         }
 
         if mailbox::receive() != 0 {
-            process_kern_message(io, aux_mutex,
-                routing_table, up_destinations,
-                ddma_mutex, subkernel_mutex,
-                Some(stream), &mut session)?;
+            process_kern_message(
+                io,
+                aux_mutex,
+                routing_table,
+                up_destinations,
+                ddma_mutex,
+                subkernel_mutex,
+                Some(stream),
+                &mut session,
+            )?;
         }
 
         if session.kernel_state == KernelState::Running {
             if !rtio_clocking::crg::check() {
                 host_write(stream, host::Reply::ClockFailure)?;
-                return Err(Error::ClockFailure)
+                return Err(Error::ClockFailure);
             }
         }
 
@@ -835,27 +1090,41 @@ fn host_kernel_worker(io: &Io, aux_mutex: &Mutex,
     }
 }
 
-fn flash_kernel_worker(io: &Io, aux_mutex: &Mutex,
-                       routing_table: &drtio_routing::RoutingTable,
-                       up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
-                       ddma_mutex: &Mutex, subkernel_mutex: &Mutex, congress: &mut Congress,
-                       config_key: &str) -> Result<(), Error<SchedError>> {
+fn flash_kernel_worker(
+    io: &Io,
+    aux_mutex: &Mutex,
+    routing_table: &drtio_routing::RoutingTable,
+    up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
+    ddma_mutex: &Mutex,
+    subkernel_mutex: &Mutex,
+    congress: &mut Congress,
+    config_key: &str,
+) -> Result<(), Error<SchedError>> {
     let mut session = Session::new(congress);
 
     config::read(config_key, |result| {
         match result {
             Ok(kernel) => {
                 // process .ELF or .TAR kernels
-                let res = process_flash_kernel(io, aux_mutex, subkernel_mutex, ddma_mutex, routing_table, up_destinations, &mut session, kernel);
+                let res = process_flash_kernel(
+                    io,
+                    aux_mutex,
+                    subkernel_mutex,
+                    ddma_mutex,
+                    routing_table,
+                    up_destinations,
+                    &mut session,
+                    kernel,
+                );
                 #[cfg(has_drtio)]
                 match res {
                     // wait to establish the DRTIO connection
                     Err(Error::DestinationDown) => io.sleep(500)?,
-                    _ => ()
+                    _ => (),
                 }
                 res
             }
-            _ => Err(Error::KernelNotFound)
+            _ => Err(Error::KernelNotFound),
         }
     })?;
     kern_run(&mut session)?;
@@ -866,13 +1135,22 @@ fn flash_kernel_worker(io: &Io, aux_mutex: &Mutex,
         }
 
         if mailbox::receive() != 0 {
-            if process_kern_message(io, aux_mutex, routing_table, up_destinations, ddma_mutex, subkernel_mutex, None, &mut session)? {
-                return Ok(())
+            if process_kern_message(
+                io,
+                aux_mutex,
+                routing_table,
+                up_destinations,
+                ddma_mutex,
+                subkernel_mutex,
+                None,
+                &mut session,
+            )? {
+                return Ok(());
             }
         }
 
         if !rtio_clocking::crg::check() {
-            return Err(Error::ClockFailure)
+            return Err(Error::ClockFailure);
         }
 
         io.relinquish()?
@@ -880,7 +1158,9 @@ fn flash_kernel_worker(io: &Io, aux_mutex: &Mutex,
 }
 
 fn respawn<F>(io: &Io, handle: &mut Option<ThreadHandle>, f: F)
-        where F: 'static + FnOnce(Io) + Send {
+where
+    F: 'static + FnOnce(Io) + Send,
+{
     match handle.take() {
         None => (),
         Some(handle) => {
@@ -894,10 +1174,14 @@ fn respawn<F>(io: &Io, handle: &mut Option<ThreadHandle>, f: F)
     *handle = Some(io.spawn(32768, f))
 }
 
-pub fn thread(io: Io, aux_mutex: &Mutex,
-        routing_table: &Urc<RefCell<drtio_routing::RoutingTable>>,
-        up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
-        ddma_mutex: &Mutex, subkernel_mutex: &Mutex) {
+pub fn thread(
+    io: Io,
+    aux_mutex: &Mutex,
+    routing_table: &Urc<RefCell<drtio_routing::RoutingTable>>,
+    up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>,
+    ddma_mutex: &Mutex,
+    subkernel_mutex: &Mutex,
+) {
     let listener = TcpListener::new(&io, 65535);
     listener.listen(1381).expect("session: cannot listen");
     info!("accepting network sessions");
@@ -909,12 +1193,18 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
         let routing_table = routing_table.borrow();
         let mut congress = congress.borrow_mut();
         info!("running startup kernel");
-        match flash_kernel_worker(&io, &aux_mutex, &routing_table, &up_destinations, 
-                ddma_mutex, subkernel_mutex, &mut congress, "startup_kernel") {
-            Ok(()) =>
-                info!("startup kernel finished"),
-            Err(Error::KernelNotFound) =>
-                info!("no startup kernel found"),
+        match flash_kernel_worker(
+            &io,
+            &aux_mutex,
+            &routing_table,
+            &up_destinations,
+            ddma_mutex,
+            subkernel_mutex,
+            &mut congress,
+            "startup_kernel",
+        ) {
+            Ok(()) => info!("startup kernel finished"),
+            Err(Error::KernelNotFound) => info!("no startup kernel found"),
             Err(err) => {
                 congress.finished_cleanly.set(false);
                 error!("startup kernel aborted: {}", err);
@@ -933,7 +1223,7 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
                 Err(_) => {
                     warn!("wrong magic from {}", stream.remote_endpoint());
                     stream.close().expect("session: cannot close");
-                    continue
+                    continue;
                 }
             }
             match stream.write_all("e".as_bytes()) {
@@ -941,7 +1231,7 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
                 Err(_) => {
                     warn!("cannot send endian byte");
                     stream.close().expect("session: cannot close");
-                    continue
+                    continue;
                 }
             }
             info!("new connection from {}", stream.remote_endpoint());
@@ -957,13 +1247,23 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
                 let routing_table = routing_table.borrow();
                 let mut congress = congress.borrow_mut();
                 let mut stream = TcpStream::from_handle(&io, stream);
-                match host_kernel_worker(&io, &aux_mutex, &routing_table, &up_destinations, 
-                        &ddma_mutex, &subkernel_mutex, &mut stream, &mut *congress) {
+                match host_kernel_worker(
+                    &io,
+                    &aux_mutex,
+                    &routing_table,
+                    &up_destinations,
+                    &ddma_mutex,
+                    &subkernel_mutex,
+                    &mut stream,
+                    &mut *congress,
+                ) {
                     Ok(()) => (),
-                    Err(Error::Protocol(host::Error::Io(IoError::UnexpectedEnd))) =>
-                        info!("connection closed"),
-                    Err(Error::Protocol(host::Error::Io(
-                            IoError::Other(SchedError::Interrupted)))) => {
+                    Err(Error::Protocol(host::Error::Io(IoError::UnexpectedEnd))) => {
+                        info!("connection closed")
+                    }
+                    Err(Error::Protocol(host::Error::Io(IoError::Other(
+                        SchedError::Interrupted,
+                    )))) => {
                         info!("kernel interrupted");
                         #[cfg(has_drtio)]
                         drtio::clear_buffers(&io, &aux_mutex);
@@ -979,7 +1279,7 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
                     match stream.close() {
                         Ok(_) => break,
                         Err(SchedError::Interrupted) => (),
-                        Err(e) => panic!("session: close socket: {:?}", e)
+                        Err(e) => panic!("session: close socket: {:?}", e),
                     };
                 }
             });
@@ -997,12 +1297,20 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
             respawn(&io, &mut kernel_thread, move |io| {
                 let routing_table = routing_table.borrow();
                 let mut congress = congress.borrow_mut();
-                match flash_kernel_worker(&io, &aux_mutex, &routing_table, &up_destinations, 
-                    &ddma_mutex, &subkernel_mutex, &mut *congress, "idle_kernel") {
-                    Ok(()) =>
-                        info!("idle kernel finished, standing by"),
-                    Err(Error::Protocol(host::Error::Io(
-                            IoError::Other(SchedError::Interrupted)))) => {
+                match flash_kernel_worker(
+                    &io,
+                    &aux_mutex,
+                    &routing_table,
+                    &up_destinations,
+                    &ddma_mutex,
+                    &subkernel_mutex,
+                    &mut *congress,
+                    "idle_kernel",
+                ) {
+                    Ok(()) => info!("idle kernel finished, standing by"),
+                    Err(Error::Protocol(host::Error::Io(IoError::Other(
+                        SchedError::Interrupted,
+                    )))) => {
                         info!("idle kernel interrupted");
                         // clear state for regular kernel
                         #[cfg(has_drtio)]
@@ -1018,7 +1326,6 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
                         drtio::clear_buffers(&io, &aux_mutex);
                     }
                 }
-
             })
         }
 

--- a/artiq/firmware/runtime/session.rs
+++ b/artiq/firmware/runtime/session.rs
@@ -497,12 +497,12 @@ fn process_host_message(
             unsafe {
                 let exn = eh::eh_artiq::Exception {
                     id: id,
-                    message: CSlice::new(message as *const u8, usize::MAX),
+                    message: message.into(),
                     param: param,
-                    file: CSlice::new(file as *const u8, usize::MAX),
+                    file: file.into(),
                     line: line,
                     column: column,
-                    function: CSlice::new(function as *const u8, usize::MAX),
+                    function: function.into(),
                 };
                 kern_send(io, &kern::RpcRecvReply(Err(exn)))?;
             }

--- a/artiq/firmware/satman/kernel.rs
+++ b/artiq/firmware/satman/kernel.rs
@@ -516,12 +516,14 @@ impl Manager {
         match (HostKernelException {
             exceptions: &[Some(eh_artiq::Exception {
                 id: 11, // SubkernelError, defined in ksupport
-                message: format!("in subkernel id {}: {:?}", self.current_id, cause).as_c_slice(),
+                message: format!("in subkernel id {}: {:?}", self.current_id, cause)
+                    .as_str()
+                    .into(),
                 param: [0, 0, 0],
-                file: file!().as_c_slice(),
+                file: file!().into(),
                 line: line!(),
                 column: column!(),
-                function: format!("subkernel id {}", self.current_id).as_c_slice(),
+                function: format!("subkernel id {}", self.current_id).as_str().into(),
             })],
             stack_pointers: &[StackPointerBacktrace {
                 stack_pointer: 0,

--- a/artiq/firmware/satman/kernel.rs
+++ b/artiq/firmware/satman/kernel.rs
@@ -1,29 +1,30 @@
+use alloc::{collections::btree_map::BTreeMap, format, string::String, vec::Vec};
 use core::mem;
-use alloc::{string::String, format, vec::Vec, collections::btree_map::BTreeMap};
-use cslice::{CSlice, AsCSlice};
+use cslice::{AsCSlice, CSlice};
 
-use board_artiq::{drtioaux, drtio_routing::RoutingTable, mailbox, spi};
-use board_misoc::{csr, clock, i2c};
-use proto_artiq::{
-    drtioaux_proto::PayloadStatus,
-    kernel_proto as kern,
-    session_proto::Reply::KernelException as HostKernelException, 
-    rpc_proto as rpc};
+use board_artiq::{drtio_routing::RoutingTable, drtioaux, mailbox, spi};
+use board_misoc::{clock, csr, i2c};
 use eh::eh_artiq;
 use io::{Cursor, ProtoRead};
 use kernel::eh_artiq::StackPointerBacktrace;
+use proto_artiq::{
+    drtioaux_proto::PayloadStatus, kernel_proto as kern, rpc_proto as rpc,
+    session_proto::Reply::KernelException as HostKernelException,
+};
 
-use ::{cricon_select, RtioMaster};
 use cache::Cache;
-use dma::{Manager as DmaManager, Error as DmaError};
-use routing::{Router, Sliceable, SliceMeta};
+use dma::{Error as DmaError, Manager as DmaManager};
+use routing::{Router, SliceMeta, Sliceable};
 use MASTER_PAYLOAD_MAX_SIZE;
+use {cricon_select, RtioMaster};
 
 mod kernel_cpu {
     use super::*;
     use core::ptr;
 
-    use proto_artiq::kernel_proto::{KERNELCPU_EXEC_ADDRESS, KERNELCPU_LAST_ADDRESS, KSUPPORT_HEADER_SIZE};
+    use proto_artiq::kernel_proto::{
+        KERNELCPU_EXEC_ADDRESS, KERNELCPU_LAST_ADDRESS, KSUPPORT_HEADER_SIZE,
+    };
 
     pub unsafe fn start() {
         if csr::kernel_cpu::reset_read() == 0 {
@@ -32,15 +33,17 @@ mod kernel_cpu {
 
         stop();
 
-        extern {
+        extern "C" {
             static _binary____ksupport_ksupport_elf_start: u8;
             static _binary____ksupport_ksupport_elf_end: u8;
         }
         let ksupport_start = &_binary____ksupport_ksupport_elf_start as *const _;
-        let ksupport_end   = &_binary____ksupport_ksupport_elf_end as *const _;
-        ptr::copy_nonoverlapping(ksupport_start,
-                                (KERNELCPU_EXEC_ADDRESS - KSUPPORT_HEADER_SIZE) as *mut u8,
-                                ksupport_end as usize - ksupport_start as usize);
+        let ksupport_end = &_binary____ksupport_ksupport_elf_end as *const _;
+        ptr::copy_nonoverlapping(
+            ksupport_start,
+            (KERNELCPU_EXEC_ADDRESS - KSUPPORT_HEADER_SIZE) as *mut u8,
+            ksupport_end as usize - ksupport_start as usize,
+        );
 
         csr::kernel_cpu::reset_write(0);
     }
@@ -62,13 +65,26 @@ enum KernelState {
     Absent,
     Loaded,
     Running,
-    MsgAwait { id: u32, max_time: i64, tags: Vec<u8> },
+    MsgAwait {
+        id: u32,
+        max_time: i64,
+        tags: Vec<u8>,
+    },
     MsgSending,
     SubkernelAwaitLoad,
-    SubkernelAwaitFinish { max_time: i64, id: u32 },
-    DmaUploading { max_time: u64 },
-    DmaAwait { max_time: u64 },
-    SubkernelRetrievingException { destination: u8 },
+    SubkernelAwaitFinish {
+        max_time: i64,
+        id: u32,
+    },
+    DmaUploading {
+        max_time: u64,
+    },
+    DmaAwait {
+        max_time: u64,
+    },
+    SubkernelRetrievingException {
+        destination: u8,
+    },
 }
 
 #[derive(Debug)]
@@ -111,7 +127,7 @@ macro_rules! unexpected {
 struct Message {
     id: u32,
     count: u8,
-    data: Vec<u8>
+    data: Vec<u8>,
 }
 
 #[derive(PartialEq)]
@@ -119,7 +135,7 @@ enum OutMessageState {
     NoMessage,
     MessageBeingSent,
     MessageSent,
-    MessageAcknowledged
+    MessageAcknowledged,
 }
 
 /* for dealing with incoming and outgoing interkernel messages */
@@ -134,8 +150,8 @@ struct MessageManager {
 struct Session {
     kernel_state: KernelState,
     log_buffer: String,
-    last_exception: Option<Sliceable>,  // exceptions raised locally
-    external_exception: Vec<u8>,  // exceptions from sub-subkernels
+    last_exception: Option<Sliceable>, // exceptions raised locally
+    external_exception: Vec<u8>,       // exceptions from sub-subkernels
     // which destination requested running the kernel
     source: u8,
     messages: MessageManager,
@@ -146,7 +162,7 @@ struct Session {
 #[derive(Debug)]
 struct KernelLibrary {
     library: Vec<u8>,
-    complete: bool
+    complete: bool,
 }
 
 pub struct Manager {
@@ -154,14 +170,14 @@ pub struct Manager {
     current_id: u32,
     session: Session,
     cache: Cache,
-    last_finished: Option<SubkernelFinished>
+    last_finished: Option<SubkernelFinished>,
 }
 
 pub struct SubkernelFinished {
     pub id: u32,
     pub with_exception: bool,
     pub exception_source: u8,
-    pub source: u8
+    pub source: u8,
 }
 
 impl MessageManager {
@@ -170,11 +186,17 @@ impl MessageManager {
             out_message: None,
             out_state: OutMessageState::NoMessage,
             in_queue: Vec::new(),
-            in_buffer: None
+            in_buffer: None,
         }
     }
 
-    pub fn handle_incoming(&mut self, status: PayloadStatus, length: usize, id: u32, data: &[u8; MASTER_PAYLOAD_MAX_SIZE]) {
+    pub fn handle_incoming(
+        &mut self,
+        status: PayloadStatus,
+        length: usize,
+        id: u32,
+        data: &[u8; MASTER_PAYLOAD_MAX_SIZE],
+    ) {
         // called when receiving a message from master
         if status.is_first() {
             // clear the buffer for first message
@@ -186,7 +208,7 @@ impl MessageManager {
                 self.in_buffer = Some(Message {
                     id: id,
                     count: data[0],
-                    data: data[1..length].to_vec()
+                    data: data[1..length].to_vec(),
                 });
             }
         };
@@ -201,12 +223,15 @@ impl MessageManager {
             OutMessageState::MessageAcknowledged => {
                 self.out_state = OutMessageState::NoMessage;
                 true
-            },
-            _ => false
+            }
+            _ => false,
         }
     }
 
-    pub fn get_outgoing_slice(&mut self, data_slice: &mut [u8; MASTER_PAYLOAD_MAX_SIZE]) -> Option<SliceMeta> {
+    pub fn get_outgoing_slice(
+        &mut self,
+        data_slice: &mut [u8; MASTER_PAYLOAD_MAX_SIZE],
+    ) -> Option<SliceMeta> {
         if self.out_state != OutMessageState::MessageBeingSent {
             return None;
         }
@@ -227,18 +252,26 @@ impl MessageManager {
             OutMessageState::MessageSent => {
                 self.out_state = OutMessageState::MessageAcknowledged;
                 false
-            },
-            _ => { 
-                warn!("received unsolicited SubkernelMessageAck"); 
-                false 
+            }
+            _ => {
+                warn!("received unsolicited SubkernelMessageAck");
+                false
             }
         }
     }
 
-    pub fn accept_outgoing(&mut self, id: u32, self_destination: u8, destination: u8, 
-        count: u8, tag: &[u8], data: *const *const (), 
-        routing_table: &RoutingTable, rank: u8, router: &mut Router
-    ) -> Result<(), Error>  {
+    pub fn accept_outgoing(
+        &mut self,
+        id: u32,
+        self_destination: u8,
+        destination: u8,
+        count: u8,
+        tag: &[u8],
+        data: *const *const (),
+        routing_table: &RoutingTable,
+        rank: u8,
+        router: &mut Router,
+    ) -> Result<(), Error> {
         let mut writer = Cursor::new(Vec::new());
         rpc::send_args(&mut writer, 0, tag, data, false)?;
         // skip service tag, but write the count
@@ -249,10 +282,19 @@ impl MessageManager {
         let mut data_slice: [u8; MASTER_PAYLOAD_MAX_SIZE] = [0; MASTER_PAYLOAD_MAX_SIZE];
         self.out_state = OutMessageState::MessageBeingSent;
         let meta = self.get_outgoing_slice(&mut data_slice).unwrap();
-        router.route(drtioaux::Packet::SubkernelMessage {
-                source: self_destination, destination: destination, id: id,
-                status: meta.status, length: meta.len as u16, data: data_slice
-        }, routing_table, rank, self_destination);
+        router.route(
+            drtioaux::Packet::SubkernelMessage {
+                source: self_destination,
+                destination: destination,
+                id: id,
+                status: meta.status,
+                length: meta.len as u16,
+                data: data_slice,
+            },
+            routing_table,
+            rank,
+            self_destination,
+        );
         Ok(())
     }
 
@@ -283,14 +325,14 @@ impl Session {
             external_exception: Vec::new(),
             source: 0,
             messages: MessageManager::new(),
-            subkernels_finished: Vec::new()
+            subkernels_finished: Vec::new(),
         }
     }
 
     fn running(&self) -> bool {
         match self.kernel_state {
-            KernelState::Absent | KernelState::Loaded  => false,
-            _ => true
+            KernelState::Absent | KernelState::Loaded => false,
+            _ => true,
         }
     }
 
@@ -315,7 +357,13 @@ impl Manager {
         }
     }
 
-    pub fn add(&mut self, id: u32, status: PayloadStatus, data: &[u8], data_len: usize) -> Result<(), Error> {
+    pub fn add(
+        &mut self,
+        id: u32,
+        status: PayloadStatus,
+        data: &[u8],
+        data_len: usize,
+    ) -> Result<(), Error> {
         if status.is_first() {
             // in case master is interrupted, and subkernel is sent again, clean the state
             self.kernels.remove(&id);
@@ -325,20 +373,28 @@ impl Manager {
                 if kernel.complete {
                     // replace entry
                     self.kernels.remove(&id);
-                    self.kernels.insert(id, KernelLibrary {
-                        library: Vec::new(),
-                        complete: false });
+                    self.kernels.insert(
+                        id,
+                        KernelLibrary {
+                            library: Vec::new(),
+                            complete: false,
+                        },
+                    );
                     self.kernels.get_mut(&id).unwrap()
                 } else {
                     kernel
                 }
-            },
+            }
             None => {
-                self.kernels.insert(id, KernelLibrary {
-                    library: Vec::new(),
-                    complete: false });
+                self.kernels.insert(
+                    id,
+                    KernelLibrary {
+                        library: Vec::new(),
+                        complete: false,
+                    },
+                );
                 self.kernels.get_mut(&id).unwrap()
-            },
+            }
         };
         kernel.library.extend(&data[0..data_len]);
 
@@ -353,7 +409,7 @@ impl Manager {
     pub fn get_current_id(&self) -> Option<u32> {
         match self.is_running() {
             true => Some(self.current_id),
-            false => None
+            false => None,
         }
     }
 
@@ -365,25 +421,35 @@ impl Manager {
 
     pub fn run(&mut self, source: u8, id: u32, timestamp: u64) -> Result<(), Error> {
         info!("starting subkernel #{}", id);
-        if self.session.kernel_state != KernelState::Loaded
-            || self.current_id != id {
+        if self.session.kernel_state != KernelState::Loaded || self.current_id != id {
             self.load(id)?;
-        } 
+        }
         self.session.source = source;
         self.session.kernel_state = KernelState::Running;
         cricon_select(RtioMaster::Kernel);
-    
+
         kern_send(&kern::UpdateNow(timestamp))
     }
 
-    pub fn message_handle_incoming(&mut self, status: PayloadStatus, length: usize, id: u32, slice: &[u8; MASTER_PAYLOAD_MAX_SIZE]) {
+    pub fn message_handle_incoming(
+        &mut self,
+        status: PayloadStatus,
+        length: usize,
+        id: u32,
+        slice: &[u8; MASTER_PAYLOAD_MAX_SIZE],
+    ) {
         if !self.is_running() {
             return;
         }
-        self.session.messages.handle_incoming(status, length, id, slice);
+        self.session
+            .messages
+            .handle_incoming(status, length, id, slice);
     }
-    
-    pub fn message_get_slice(&mut self, slice: &mut [u8; MASTER_PAYLOAD_MAX_SIZE]) -> Option<SliceMeta> {
+
+    pub fn message_get_slice(
+        &mut self,
+        slice: &mut [u8; MASTER_PAYLOAD_MAX_SIZE],
+    ) -> Option<SliceMeta> {
         if !self.is_running() {
             return None;
         }
@@ -400,42 +466,47 @@ impl Manager {
 
     pub fn load(&mut self, id: u32) -> Result<(), Error> {
         if self.current_id == id && self.session.kernel_state == KernelState::Loaded {
-            return Ok(())
+            return Ok(());
         }
         if !self.kernels.get(&id).ok_or(Error::KernelNotFound)?.complete {
-            return Err(Error::KernelNotFound)
+            return Err(Error::KernelNotFound);
         }
         self.current_id = id;
         self.session = Session::new();
         self.stop();
-        
-        unsafe { 
+
+        unsafe {
             kernel_cpu::start();
 
             kern_send(&kern::LoadRequest(&self.kernels.get(&id).unwrap().library)).unwrap();
-            kern_recv(|reply| {
-                match reply {
-                    kern::LoadReply(Ok(())) => {
-                        self.session.kernel_state = KernelState::Loaded;
-                        Ok(())
-                    }
-                    kern::LoadReply(Err(error)) => {
-                        kernel_cpu::stop();
-                        error!("load error: {:?}", error);
-                        Err(Error::Load(format!("{}", error)))
-                    }
-                    other => {
-                        unexpected!("unexpected kernel CPU reply to load request: {:?}", other)
-                    }
+            kern_recv(|reply| match reply {
+                kern::LoadReply(Ok(())) => {
+                    self.session.kernel_state = KernelState::Loaded;
+                    Ok(())
+                }
+                kern::LoadReply(Err(error)) => {
+                    kernel_cpu::stop();
+                    error!("load error: {:?}", error);
+                    Err(Error::Load(format!("{}", error)))
+                }
+                other => {
+                    unexpected!("unexpected kernel CPU reply to load request: {:?}", other)
                 }
             })
         }
     }
 
-    pub fn exception_get_slice(&mut self, data_slice: &mut [u8; MASTER_PAYLOAD_MAX_SIZE]) -> SliceMeta {
+    pub fn exception_get_slice(
+        &mut self,
+        data_slice: &mut [u8; MASTER_PAYLOAD_MAX_SIZE],
+    ) -> SliceMeta {
         match self.session.last_exception.as_mut() {
             Some(exception) => exception.get_slice_master(data_slice),
-            None => SliceMeta { destination: 0, len: 0, status: PayloadStatus::FirstAndLast }
+            None => SliceMeta {
+                destination: 0,
+                len: 0,
+                status: PayloadStatus::FirstAndLast,
+            },
         }
     }
 
@@ -444,32 +515,38 @@ impl Manager {
         let mut writer = Cursor::new(raw_exception);
         match (HostKernelException {
             exceptions: &[Some(eh_artiq::Exception {
-                id:       11,  // SubkernelError, defined in ksupport
-                message:  format!("in subkernel id {}: {:?}", self.current_id, cause).as_c_slice(),
-                param:    [0, 0, 0],
-                file:     file!().as_c_slice(),
-                line:     line!(),
-                column:   column!(),
+                id: 11, // SubkernelError, defined in ksupport
+                message: format!("in subkernel id {}: {:?}", self.current_id, cause).as_c_slice(),
+                param: [0, 0, 0],
+                file: file!().as_c_slice(),
+                line: line!(),
+                column: column!(),
                 function: format!("subkernel id {}", self.current_id).as_c_slice(),
             })],
             stack_pointers: &[StackPointerBacktrace {
                 stack_pointer: 0,
                 initial_backtrace_size: 0,
-                current_backtrace_size: 0
+                current_backtrace_size: 0,
             }],
             backtrace: &[],
-            async_errors: 0
-        }).write_to(&mut writer) {
+            async_errors: 0,
+        })
+        .write_to(&mut writer)
+        {
             Ok(_) => self.session.last_exception = Some(Sliceable::new(0, writer.into_inner())),
-            Err(_) => error!("Error writing exception data")
+            Err(_) => error!("Error writing exception data"),
         }
     }
 
     pub fn ddma_finished(&mut self, error: u8, channel: u32, timestamp: u64) {
         if let KernelState::DmaAwait { .. } = self.session.kernel_state {
-            kern_send(&kern::DmaAwaitRemoteReply { 
-                timeout: false, error: error, channel: channel, timestamp: timestamp 
-            }).unwrap();
+            kern_send(&kern::DmaAwaitRemoteReply {
+                timeout: false,
+                error: error,
+                channel: channel,
+                timestamp: timestamp,
+            })
+            .unwrap();
             self.session.kernel_state = KernelState::Running;
         }
     }
@@ -477,9 +554,13 @@ impl Manager {
     pub fn ddma_nack(&mut self) {
         // for simplicity treat it as a timeout for now...
         if let KernelState::DmaAwait { .. } = self.session.kernel_state {
-            kern_send(&kern::DmaAwaitRemoteReply { 
-                timeout: true, error: 0, channel: 0, timestamp: 0
-            }).unwrap();
+            kern_send(&kern::DmaAwaitRemoteReply {
+                timeout: true,
+                error: 0,
+                channel: 0,
+                timestamp: 0,
+            })
+            .unwrap();
             self.session.kernel_state = KernelState::Running;
         }
     }
@@ -496,24 +577,48 @@ impl Manager {
         }
     }
 
-    pub fn process_kern_requests(&mut self, router: &mut Router, routing_table: &RoutingTable, rank: u8, destination: u8, dma_manager: &mut DmaManager) {
+    pub fn process_kern_requests(
+        &mut self,
+        router: &mut Router,
+        routing_table: &RoutingTable,
+        rank: u8,
+        destination: u8,
+        dma_manager: &mut DmaManager,
+    ) {
         macro_rules! finished {
-            ($with_exception:expr) => {{ Some(SubkernelFinished { 
-                source: self.session.source, id: self.current_id, 
-                with_exception: $with_exception, exception_source: destination 
-            }) }}
+            ($with_exception:expr) => {{
+                Some(SubkernelFinished {
+                    source: self.session.source,
+                    id: self.current_id,
+                    with_exception: $with_exception,
+                    exception_source: destination,
+                })
+            }};
         }
 
         if let Some(subkernel_finished) = self.last_finished.take() {
-            info!("subkernel {} finished, with exception: {}", subkernel_finished.id, subkernel_finished.with_exception);
+            info!(
+                "subkernel {} finished, with exception: {}",
+                subkernel_finished.id, subkernel_finished.with_exception
+            );
             let pending = self.session.messages.pending_ids();
             if pending.len() > 0 {
-                warn!("subkernel terminated with messages still pending: {:?}", pending);
+                warn!(
+                    "subkernel terminated with messages still pending: {:?}",
+                    pending
+                );
             }
-            router.route(drtioaux::Packet::SubkernelFinished {
-                destination: subkernel_finished.source, id: subkernel_finished.id, 
-                with_exception: subkernel_finished.with_exception, exception_src: subkernel_finished.exception_source
-            }, &routing_table, rank, destination);
+            router.route(
+                drtioaux::Packet::SubkernelFinished {
+                    destination: subkernel_finished.source,
+                    id: subkernel_finished.id,
+                    with_exception: subkernel_finished.with_exception,
+                    exception_src: subkernel_finished.exception_source,
+                },
+                &routing_table,
+                rank,
+                destination,
+            );
             dma_manager.cleanup(router, rank, destination, routing_table);
         }
 
@@ -530,30 +635,35 @@ impl Manager {
                 unsafe { self.cache.unborrow() }
                 self.session.last_exception = Some(exception);
                 self.last_finished = finished!(true);
-            },
-            Err(e) => { 
+            }
+            Err(e) => {
                 error!("Error while running processing external messages: {:?}", e);
                 self.stop();
                 self.runtime_exception(e);
                 self.last_finished = finished!(true);
-             }
+            }
         }
 
         match self.process_kern_message(router, routing_table, rank, destination, dma_manager) {
-            Ok(Some(with_exception)) => {
-                self.last_finished = finished!(with_exception)
-            },
+            Ok(Some(with_exception)) => self.last_finished = finished!(with_exception),
             Ok(None) | Err(Error::NoMessage) => (),
-            Err(e) => { 
-                error!("Error while running kernel: {:?}", e); 
-                self.stop(); 
+            Err(e) => {
+                error!("Error while running kernel: {:?}", e);
+                self.stop();
                 self.runtime_exception(e);
                 self.last_finished = finished!(true);
             }
         }
     }
 
-    fn check_finished_kernels(&mut self, id: u32, router: &mut Router, routing_table: &RoutingTable, rank: u8, self_destination: u8) {
+    fn check_finished_kernels(
+        &mut self,
+        id: u32,
+        router: &mut Router,
+        routing_table: &RoutingTable,
+        rank: u8,
+        self_destination: u8,
+    ) {
         for (i, (status, exception_source)) in self.session.subkernels_finished.iter().enumerate() {
             if *status == id {
                 if exception_source.is_none() {
@@ -563,26 +673,42 @@ impl Manager {
                 } else {
                     let destination = exception_source.unwrap();
                     self.session.external_exception = Vec::new();
-                    self.session.kernel_state = KernelState::SubkernelRetrievingException { destination: destination };
-                    router.route(drtioaux::Packet::SubkernelExceptionRequest {
-                        source: self_destination, destination: destination
-                    }, &routing_table, rank, self_destination);
+                    self.session.kernel_state = KernelState::SubkernelRetrievingException {
+                        destination: destination,
+                    };
+                    router.route(
+                        drtioaux::Packet::SubkernelExceptionRequest {
+                            source: self_destination,
+                            destination: destination,
+                        },
+                        &routing_table,
+                        rank,
+                        self_destination,
+                    );
                 }
                 break;
             }
         }
     }
 
-    fn process_external_messages(&mut self, router: &mut Router, routing_table: &RoutingTable, rank: u8, self_destination: u8) -> Result<(), Error> {
+    fn process_external_messages(
+        &mut self,
+        router: &mut Router,
+        routing_table: &RoutingTable,
+        rank: u8,
+        self_destination: u8,
+    ) -> Result<(), Error> {
         match &self.session.kernel_state {
             KernelState::MsgAwait { id, max_time, tags } => {
                 if *max_time > 0 && clock::get_ms() > *max_time as u64 {
                     kern_send(&kern::SubkernelError(kern::SubkernelStatus::Timeout))?;
                     self.session.kernel_state = KernelState::Running;
-                    return Ok(())
+                    return Ok(());
                 }
                 if let Some(message) = self.session.messages.get_incoming(*id) {
-                    kern_send(&kern::SubkernelMsgRecvReply { count: message.count })?;
+                    kern_send(&kern::SubkernelMsgRecvReply {
+                        count: message.count,
+                    })?;
                     let tags = tags.clone();
                     self.session.kernel_state = KernelState::Running;
                     pass_message_to_kernel(&message, &tags)
@@ -591,7 +717,7 @@ impl Manager {
                     self.check_finished_kernels(id, router, routing_table, rank, self_destination);
                     Err(Error::AwaitingMessage)
                 }
-            },
+            }
             KernelState::MsgSending => {
                 if self.session.messages.was_message_acknowledged() {
                     self.session.kernel_state = KernelState::Running;
@@ -599,7 +725,7 @@ impl Manager {
                 } else {
                     Err(Error::AwaitingMessage)
                 }
-            },
+            }
             KernelState::SubkernelAwaitFinish { max_time, id } => {
                 if *max_time > 0 && clock::get_ms() > *max_time as u64 {
                     kern_send(&kern::SubkernelError(kern::SubkernelStatus::Timeout))?;
@@ -612,7 +738,12 @@ impl Manager {
             }
             KernelState::DmaAwait { max_time } => {
                 if clock::get_ms() > *max_time {
-                    kern_send(&kern::DmaAwaitRemoteReply { timeout: true, error: 0, channel: 0, timestamp: 0 })?;
+                    kern_send(&kern::DmaAwaitRemoteReply {
+                        timeout: true,
+                        error: 0,
+                        channel: 0,
+                        timestamp: 0,
+                    })?;
                     self.session.kernel_state = KernelState::Running;
                 }
                 // ddma_finished() and nack() covers the other case
@@ -627,18 +758,22 @@ impl Manager {
             KernelState::SubkernelRetrievingException { destination: _ } => {
                 Err(Error::AwaitingMessage)
             }
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 
     pub fn subkernel_load_run_reply(&mut self, succeeded: bool, self_destination: u8) {
         if self.session.kernel_state == KernelState::SubkernelAwaitLoad {
-            if let Err(e) = kern_send(&kern::SubkernelLoadRunReply { succeeded: succeeded }) {
-                self.stop(); 
+            if let Err(e) = kern_send(&kern::SubkernelLoadRunReply {
+                succeeded: succeeded,
+            }) {
+                self.stop();
                 self.runtime_exception(e);
-                self.last_finished = Some(SubkernelFinished { 
-                    source: self.session.source, id: self.current_id, 
-                    with_exception: true, exception_source: self_destination 
+                self.last_finished = Some(SubkernelFinished {
+                    source: self.session.source,
+                    id: self.current_id,
+                    with_exception: true,
+                    exception_source: self_destination,
                 })
             } else {
                 self.session.kernel_state = KernelState::Running;
@@ -648,68 +783,102 @@ impl Manager {
         }
     }
 
-    pub fn remote_subkernel_finished(&mut self, id: u32, with_exception: bool, exception_source: u8) {
-        let exception_src = if with_exception { Some(exception_source) } else { None };
+    pub fn remote_subkernel_finished(
+        &mut self,
+        id: u32,
+        with_exception: bool,
+        exception_source: u8,
+    ) {
+        let exception_src = if with_exception {
+            Some(exception_source)
+        } else {
+            None
+        };
         self.session.subkernels_finished.push((id, exception_src));
     }
 
-    pub fn received_exception(&mut self, exception_data: &[u8], last: bool, router: &mut Router, routing_table: &RoutingTable,
-        rank: u8, self_destination: u8) {
-        if let KernelState::SubkernelRetrievingException { destination } = self.session.kernel_state {
-            self.session.external_exception.extend_from_slice(exception_data);
+    pub fn received_exception(
+        &mut self,
+        exception_data: &[u8],
+        last: bool,
+        router: &mut Router,
+        routing_table: &RoutingTable,
+        rank: u8,
+        self_destination: u8,
+    ) {
+        if let KernelState::SubkernelRetrievingException { destination } = self.session.kernel_state
+        {
+            self.session
+                .external_exception
+                .extend_from_slice(exception_data);
             if last {
                 if let Ok(exception) = read_exception(&self.session.external_exception) {
-                    kern_send(&kern::SubkernelError(kern::SubkernelStatus::Exception(exception))).unwrap();
+                    kern_send(&kern::SubkernelError(kern::SubkernelStatus::Exception(
+                        exception,
+                    )))
+                    .unwrap();
                 } else {
-                    kern_send(
-                        &kern::SubkernelError(kern::SubkernelStatus::OtherError)).unwrap();
+                    kern_send(&kern::SubkernelError(kern::SubkernelStatus::OtherError)).unwrap();
                 }
                 self.session.kernel_state = KernelState::Running;
             } else {
                 /* fetch another slice */
-                router.route(drtioaux::Packet::SubkernelExceptionRequest {
-                    source: self_destination, destination: destination
-                }, routing_table, rank, self_destination);
+                router.route(
+                    drtioaux::Packet::SubkernelExceptionRequest {
+                        source: self_destination,
+                        destination: destination,
+                    },
+                    routing_table,
+                    rank,
+                    self_destination,
+                );
             }
         } else {
             warn!("Received unsolicited exception data");
         }
     }
 
-    fn process_kern_message(&mut self, router: &mut Router, 
+    fn process_kern_message(
+        &mut self,
+        router: &mut Router,
         routing_table: &RoutingTable,
-        rank: u8, destination: u8,
-        dma_manager: &mut DmaManager
+        rank: u8,
+        destination: u8,
+        dma_manager: &mut DmaManager,
     ) -> Result<Option<bool>, Error> {
         // returns Ok(with_exception) on finish
         // None if the kernel is still running
         kern_recv(|request| {
             match (request, &self.session.kernel_state) {
-                (&kern::LoadReply(_), KernelState::Loaded) |
-                    (_, KernelState::DmaUploading { .. }) |
-                    (_, KernelState::DmaAwait { .. }) |
-                    (_, KernelState::MsgSending) |
-                    (_, KernelState::SubkernelAwaitLoad) | 
-                    (_, KernelState::SubkernelRetrievingException { .. }) |
-                    (_, KernelState::SubkernelAwaitFinish { .. }) => {
+                (&kern::LoadReply(_), KernelState::Loaded)
+                | (_, KernelState::DmaUploading { .. })
+                | (_, KernelState::DmaAwait { .. })
+                | (_, KernelState::MsgSending)
+                | (_, KernelState::SubkernelAwaitLoad)
+                | (_, KernelState::SubkernelRetrievingException { .. })
+                | (_, KernelState::SubkernelAwaitFinish { .. }) => {
                     // We're standing by; ignore the message.
-                    return Ok(None)
+                    return Ok(None);
                 }
                 (_, KernelState::Running) => (),
                 _ => {
-                    unexpected!("unexpected request {:?} from kernel CPU in {:?} state",
-                                request, self.session.kernel_state)
-                },
+                    unexpected!(
+                        "unexpected request {:?} from kernel CPU in {:?} state",
+                        request,
+                        self.session.kernel_state
+                    )
+                }
             }
 
             if process_kern_hwreq(request, destination)? {
-                return Ok(None)
+                return Ok(None);
             }
 
             match request {
                 &kern::Log(args) => {
                     use core::fmt::Write;
-                    self.session.log_buffer
+                    self.session
+                        .log_buffer
                         .write_fmt(args)
                         .unwrap_or_else(|_| warn!("cannot append to session log buffer"));
                     self.session.flush_log_buffer();
@@ -731,13 +900,15 @@ impl Manager {
                 &kern::CacheGetRequest { key } => {
                     let value = self.cache.get(key);
                     kern_send(&kern::CacheGetReply {
-                        value: unsafe { mem::transmute(value) }
+                        value: unsafe { mem::transmute(value) },
                     })
                 }
 
                 &kern::CachePutRequest { key, value } => {
                     let succeeded = self.cache.put(key, value).is_ok();
-                    kern_send(&kern::CachePutReply { succeeded: succeeded })
+                    kern_send(&kern::CachePutReply {
+                        succeeded: succeeded,
+                    })
                 }
 
                 &kern::RunFinished => {
@@ -745,15 +916,20 @@ impl Manager {
                     self.session.kernel_state = KernelState::Absent;
                     unsafe { self.cache.unborrow() }
 
-                    return Ok(Some(false))
+                    return Ok(Some(false));
                 }
-                &kern::RunException { exceptions, stack_pointers, backtrace } => {
+                &kern::RunException {
+                    exceptions,
+                    stack_pointers,
+                    backtrace,
+                } => {
                     unsafe { kernel_cpu::stop() }
                     self.session.kernel_state = KernelState::Absent;
-                    unsafe { self.cache.unborrow() }    
-                    let exception = slice_kernel_exception(&exceptions, &stack_pointers, &backtrace)?;
+                    unsafe { self.cache.unborrow() }
+                    let exception =
+                        slice_kernel_exception(&exceptions, &stack_pointers, &backtrace)?;
                     self.session.last_exception = Some(exception);
-                    return Ok(Some(true))
+                    return Ok(Some(true));
                 }
 
                 &kern::DmaRecordStart(name) => {
@@ -764,19 +940,29 @@ impl Manager {
                     dma_manager.record_append(data);
                     kern_acknowledge()
                 }
-                &kern::DmaRecordStop { duration, enable_ddma: _ } => {
+                &kern::DmaRecordStop {
+                    duration,
+                    enable_ddma: _,
+                } => {
                     // ddma is always used on satellites
                     if let Ok(id) = dma_manager.record_stop(duration, destination) {
-                        let remote_count = dma_manager.upload_traces(id, router, rank, destination, routing_table)?;
+                        let remote_count = dma_manager.upload_traces(
+                            id,
+                            router,
+                            rank,
+                            destination,
+                            routing_table,
+                        )?;
                         if remote_count > 0 {
                             let max_time = clock::get_ms() + 10_000 as u64;
-                            self.session.kernel_state = KernelState::DmaUploading { max_time: max_time };
+                            self.session.kernel_state =
+                                KernelState::DmaUploading { max_time: max_time };
                             Ok(())
                         } else {
                             kern_acknowledge()
                         }
                     } else {
-                        unexpected!("DMAError: found an unsupported call to RTIO devices on master") 
+                        unexpected!("DMAError: found an unsupported call to RTIO devices on master")
                     }
                 }
                 &kern::DmaEraseRequest { name } => {
@@ -786,7 +972,7 @@ impl Manager {
                 &kern::DmaRetrieveRequest { name } => {
                     dma_manager.with_trace(destination, name, |trace, duration| {
                         kern_send(&kern::DmaRetrieveReply {
-                            trace:    trace,
+                            trace: trace,
                             duration: duration,
                             uses_ddma: true,
                         })
@@ -795,12 +981,25 @@ impl Manager {
                 &kern::DmaStartRemoteRequest { id, timestamp } => {
                     let max_time = clock::get_ms() + 10_000 as u64;
                     self.session.kernel_state = KernelState::DmaAwait { max_time: max_time };
-                    dma_manager.playback_remote(id as u32, timestamp as u64, router, rank, destination, routing_table)?;
+                    dma_manager.playback_remote(
+                        id as u32,
+                        timestamp as u64,
+                        router,
+                        rank,
+                        destination,
+                        routing_table,
+                    )?;
                     dma_manager.playback(destination, id as u32, timestamp as u64)?;
                     Ok(())
                 }
 
-                &kern::SubkernelMsgSend { id, destination: msg_dest, count, tag, data } => {
+                &kern::SubkernelMsgSend {
+                    id,
+                    destination: msg_dest,
+                    count,
+                    tag,
+                    data,
+                } => {
                     let message_destination;
                     let message_id;
                     if let Some(dest) = msg_dest {
@@ -811,9 +1010,17 @@ impl Manager {
                         message_destination = self.session.source;
                         message_id = self.current_id;
                     }
-                    self.session.messages.accept_outgoing(message_id, destination,
-                        message_destination, count, tag, data, 
-                        routing_table, rank, router)?;
+                    self.session.messages.accept_outgoing(
+                        message_id,
+                        destination,
+                        message_destination,
+                        count,
+                        tag,
+                        data,
+                        routing_table,
+                        rank,
+                        router,
+                    )?;
                     // acknowledge after the message is sent
                     self.session.kernel_state = KernelState::MsgSending;
                     Ok(())
@@ -821,30 +1028,56 @@ impl Manager {
 
                 &kern::SubkernelMsgRecvRequest { id, timeout, tags } => {
                     // negative timeout value means no timeout
-                    let max_time = if timeout > 0 { clock::get_ms() as i64 + timeout } else { timeout };
+                    let max_time = if timeout > 0 {
+                        clock::get_ms() as i64 + timeout
+                    } else {
+                        timeout
+                    };
                     // ID equal to -1 indicates wildcard for receiving arguments
                     let id = if id == -1 { self.current_id } else { id as u32 };
-                    self.session.kernel_state = KernelState::MsgAwait { 
-                        id, max_time, tags: tags.to_vec() };
+                    self.session.kernel_state = KernelState::MsgAwait {
+                        id,
+                        max_time,
+                        tags: tags.to_vec(),
+                    };
                     Ok(())
-                },
+                }
 
-                &kern::SubkernelLoadRunRequest { id, destination: sk_destination, run, timestamp } => {
+                &kern::SubkernelLoadRunRequest {
+                    id,
+                    destination: sk_destination,
+                    run,
+                    timestamp,
+                } => {
                     self.session.kernel_state = KernelState::SubkernelAwaitLoad;
-                    router.route(drtioaux::Packet::SubkernelLoadRunRequest { 
-                        source: destination, destination: sk_destination, id, run, timestamp
-                    }, routing_table, rank, destination);
+                    router.route(
+                        drtioaux::Packet::SubkernelLoadRunRequest {
+                            source: destination,
+                            destination: sk_destination,
+                            id,
+                            run,
+                            timestamp,
+                        },
+                        routing_table,
+                        rank,
+                        destination,
+                    );
                     Ok(())
                 }
 
                 &kern::SubkernelAwaitFinishRequest { id, timeout } => {
-                    let max_time = if timeout > 0 { clock::get_ms() as i64 + timeout } else { timeout };
+                    let max_time = if timeout > 0 {
+                        clock::get_ms() as i64 + timeout
+                    } else {
+                        timeout
+                    };
                     self.session.kernel_state = KernelState::SubkernelAwaitFinish { max_time, id };
                     Ok(())
                 }
 
-                request => unexpected!("unexpected request {:?} from kernel CPU", request)
-            }.and(Ok(None))
+                request => unexpected!("unexpected request {:?} from kernel CPU", request),
+            }
+            .and(Ok(None))
         })
     }
 }
@@ -852,9 +1085,7 @@ impl Manager {
 impl Drop for Manager {
     fn drop(&mut self) {
         cricon_select(RtioMaster::Drtio);
-        unsafe {
-            kernel_cpu::stop() 
-        };
+        unsafe { kernel_cpu::stop() };
     }
 }
 
@@ -874,8 +1105,7 @@ fn read_exception_string<'a>(reader: &mut Cursor<&[u8]>) -> Result<CSlice<'a, u8
     }
 }
 
-fn read_exception(buffer: &[u8]) -> Result<eh_artiq::Exception, Error>
-{
+fn read_exception(buffer: &[u8]) -> Result<eh_artiq::Exception, Error> {
     let mut reader = Cursor::new(buffer);
 
     let mut byte = reader.read_u8()?;
@@ -890,29 +1120,37 @@ fn read_exception(buffer: &[u8]) -> Result<eh_artiq::Exception, Error>
     let _len = reader.read_u32()?;
     // ignore the remaining exceptions, stack traces etc. - unwinding from another device would be unwise anyway
     Ok(eh_artiq::Exception {
-        id:       reader.read_u32()?,
-        message:  read_exception_string(&mut reader)?,
-        param:    [reader.read_u64()? as i64, reader.read_u64()? as i64, reader.read_u64()? as i64],
-        file:     read_exception_string(&mut reader)?,
-        line:     reader.read_u32()?,
-        column:   reader.read_u32()?,
-        function: read_exception_string(&mut reader)?
+        id: reader.read_u32()?,
+        message: read_exception_string(&mut reader)?,
+        param: [
+            reader.read_u64()? as i64,
+            reader.read_u64()? as i64,
+            reader.read_u64()? as i64,
+        ],
+        file: read_exception_string(&mut reader)?,
+        line: reader.read_u32()?,
+        column: reader.read_u32()?,
+        function: read_exception_string(&mut reader)?,
     })
 }
 
 fn kern_recv<R, F>(f: F) -> Result<R, Error>
-        where F: FnOnce(&kern::Message) -> Result<R, Error> {
+where
+    F: FnOnce(&kern::Message) -> Result<R, Error>,
+{
     if mailbox::receive() == 0 {
         return Err(Error::NoMessage);
     };
     if !kernel_cpu::validate(mailbox::receive()) {
-        return Err(Error::InvalidPointer(mailbox::receive()))
+        return Err(Error::InvalidPointer(mailbox::receive()));
     }
     f(unsafe { &*(mailbox::receive() as *const kern::Message) })
 }
 
 fn kern_recv_w_timeout<R, F>(timeout: u64, f: F) -> Result<R, Error>
-        where F: FnOnce(&kern::Message) -> Result<R, Error> + Copy {
+where
+    F: FnOnce(&kern::Message) -> Result<R, Error> + Copy,
+{
     // sometimes kernel may be too slow to respond immediately
     // (e.g. when receiving external messages)
     // we cannot wait indefinitely to keep the satellite responsive
@@ -921,7 +1159,7 @@ fn kern_recv_w_timeout<R, F>(timeout: u64, f: F) -> Result<R, Error>
     while clock::get_ms() < max_time {
         match kern_recv(f) {
             Err(Error::NoMessage) => continue,
-            anything_else => return anything_else
+            anything_else => return anything_else,
         }
     }
     Err(Error::NoMessage)
@@ -938,9 +1176,10 @@ fn kern_send(request: &kern::Message) -> Result<(), Error> {
     Ok(())
 }
 
-fn slice_kernel_exception(exceptions: &[Option<eh_artiq::Exception>],
+fn slice_kernel_exception(
+    exceptions: &[Option<eh_artiq::Exception>],
     stack_pointers: &[eh_artiq::StackPointerBacktrace],
-    backtrace: &[(usize, usize)]
+    backtrace: &[(usize, usize)],
 ) -> Result<Sliceable, Error> {
     error!("exception in kernel");
     for exception in exceptions {
@@ -955,11 +1194,13 @@ fn slice_kernel_exception(exceptions: &[Option<eh_artiq::Exception>],
         exceptions: exceptions,
         stack_pointers: stack_pointers,
         backtrace: backtrace,
-        async_errors: 0
-    }).write_to(&mut writer) {
+        async_errors: 0,
+    })
+    .write_to(&mut writer)
+    {
         // save last exception data to be received by master
         Ok(_) => Ok(Sliceable::new(0, writer.into_inner())),
-        Err(_) => Err(Error::SubkernelIoError)
+        Err(_) => Err(Error::SubkernelIoError),
     }
 }
 
@@ -968,38 +1209,45 @@ fn pass_message_to_kernel(message: &Message, tags: &[u8]) -> Result<(), Error> {
     let mut current_tags = tags;
     let mut i = 0;
     loop {
-        let slot = kern_recv_w_timeout(100, |reply| {
-            match reply {
-                &kern::RpcRecvRequest(slot) => Ok(slot),
-                &kern::RunException { exceptions, stack_pointers, backtrace } => {
-                    let exception = slice_kernel_exception(&exceptions, &stack_pointers, &backtrace)?;
-                    Err(Error::KernelException(exception))
-                },
-                other => unexpected!(
-                    "expected root value slot from kernel CPU, not {:?}", other)
+        let slot = kern_recv_w_timeout(100, |reply| match reply {
+            &kern::RpcRecvRequest(slot) => Ok(slot),
+            &kern::RunException {
+                exceptions,
+                stack_pointers,
+                backtrace,
+            } => {
+                let exception = slice_kernel_exception(&exceptions, &stack_pointers, &backtrace)?;
+                Err(Error::KernelException(exception))
             }
+            other => unexpected!("expected root value slot from kernel CPU, not {:?}", other),
         })?;
-        let res = rpc::recv_return(&mut reader, current_tags, slot, &|size| -> Result<_, Error> {
-            if size == 0 {
-                return Ok(0 as *mut ())
-            }
-            kern_send(&kern::RpcRecvReply(Ok(size)))?;
-            Ok(kern_recv_w_timeout(100, |reply| {
-                match reply {
+        let res = rpc::recv_return(
+            &mut reader,
+            current_tags,
+            slot,
+            &|size| -> Result<_, Error> {
+                if size == 0 {
+                    return Ok(0 as *mut ());
+                }
+                kern_send(&kern::RpcRecvReply(Ok(size)))?;
+                Ok(kern_recv_w_timeout(100, |reply| match reply {
                     &kern::RpcRecvRequest(slot) => Ok(slot),
-                    &kern::RunException { 
+                    &kern::RunException {
                         exceptions,
                         stack_pointers,
-                        backtrace 
-                    }=> {
-                        let exception = slice_kernel_exception(&exceptions, &stack_pointers, &backtrace)?;
+                        backtrace,
+                    } => {
+                        let exception =
+                            slice_kernel_exception(&exceptions, &stack_pointers, &backtrace)?;
                         Err(Error::KernelException(exception))
-                    },
+                    }
                     other => unexpected!(
-                        "expected nested value slot from kernel CPU, not {:?}", other)
-                }
-            })?)
-        });
+                        "expected nested value slot from kernel CPU, not {:?}",
+                        other
+                    ),
+                })?)
+            },
+        );
         match res {
             Ok(new_tags) => {
                 kern_send(&kern::RpcRecvReply(Ok(0)))?;
@@ -1011,8 +1259,8 @@ fn pass_message_to_kernel(message: &Message, tags: &[u8]) -> Result<(), Error> {
                     // should be done by then
                     break;
                 }
-            },
-            Err(_) => unexpected!("expected valid subkernel message data")
+            }
+            Err(_) => unexpected!("expected valid subkernel message data"),
         };
     }
     Ok(())
@@ -1032,60 +1280,90 @@ fn process_kern_hwreq(request: &kern::Message, self_destination: u8) -> Result<b
         &kern::RtioDestinationStatusRequest { destination } => {
             // only local destination is considered "up"
             // no access to other DRTIO destinations
-            kern_send(&kern::RtioDestinationStatusReply { 
-                up: destination == self_destination })
+            kern_send(&kern::RtioDestinationStatusReply {
+                up: destination == self_destination,
+            })
         }
 
         &kern::I2cStartRequest { busno } => {
             let succeeded = i2c::start(busno as u8).is_ok();
-            kern_send(&kern::I2cBasicReply { succeeded: succeeded })
+            kern_send(&kern::I2cBasicReply {
+                succeeded: succeeded,
+            })
         }
         &kern::I2cRestartRequest { busno } => {
             let succeeded = i2c::restart(busno as u8).is_ok();
-            kern_send(&kern::I2cBasicReply { succeeded: succeeded })
+            kern_send(&kern::I2cBasicReply {
+                succeeded: succeeded,
+            })
         }
         &kern::I2cStopRequest { busno } => {
             let succeeded = i2c::stop(busno as u8).is_ok();
-            kern_send(&kern::I2cBasicReply { succeeded: succeeded })
+            kern_send(&kern::I2cBasicReply {
+                succeeded: succeeded,
+            })
         }
-        &kern::I2cWriteRequest { busno, data } => {
-            match i2c::write(busno as u8, data) {
-                Ok(ack) => kern_send(
-                    &kern::I2cWriteReply { succeeded: true, ack: ack }),
-                Err(_) => kern_send(
-                    &kern::I2cWriteReply { succeeded: false, ack: false })
-            }
-        }
-        &kern::I2cReadRequest { busno, ack } => {
-            match i2c::read(busno as u8, ack) {
-                Ok(data) => kern_send(
-                    &kern::I2cReadReply { succeeded: true, data: data }),
-                Err(_) => kern_send(
-                    &kern::I2cReadReply { succeeded: false, data: 0xff })
-            }
-        }
-        &kern::I2cSwitchSelectRequest { busno, address, mask } => {
+        &kern::I2cWriteRequest { busno, data } => match i2c::write(busno as u8, data) {
+            Ok(ack) => kern_send(&kern::I2cWriteReply {
+                succeeded: true,
+                ack: ack,
+            }),
+            Err(_) => kern_send(&kern::I2cWriteReply {
+                succeeded: false,
+                ack: false,
+            }),
+        },
+        &kern::I2cReadRequest { busno, ack } => match i2c::read(busno as u8, ack) {
+            Ok(data) => kern_send(&kern::I2cReadReply {
+                succeeded: true,
+                data: data,
+            }),
+            Err(_) => kern_send(&kern::I2cReadReply {
+                succeeded: false,
+                data: 0xff,
+            }),
+        },
+        &kern::I2cSwitchSelectRequest {
+            busno,
+            address,
+            mask,
+        } => {
             let succeeded = i2c::switch_select(busno as u8, address, mask).is_ok();
-            kern_send(&kern::I2cBasicReply { succeeded: succeeded })
+            kern_send(&kern::I2cBasicReply {
+                succeeded: succeeded,
+            })
         }
 
-        &kern::SpiSetConfigRequest { busno, flags, length, div, cs } => {
+        &kern::SpiSetConfigRequest {
+            busno,
+            flags,
+            length,
+            div,
+            cs,
+        } => {
             let succeeded = spi::set_config(busno as u8, flags, length, div, cs).is_ok();
-            kern_send(&kern::SpiBasicReply { succeeded: succeeded })
-        },
+            kern_send(&kern::SpiBasicReply {
+                succeeded: succeeded,
+            })
+        }
         &kern::SpiWriteRequest { busno, data } => {
             let succeeded = spi::write(busno as u8, data).is_ok();
-            kern_send(&kern::SpiBasicReply { succeeded: succeeded })
+            kern_send(&kern::SpiBasicReply {
+                succeeded: succeeded,
+            })
         }
-        &kern::SpiReadRequest { busno } => {
-            match spi::read(busno as u8) {
-                Ok(data) => kern_send(
-                    &kern::SpiReadReply { succeeded: true, data: data }),
-                Err(_) => kern_send(
-                    &kern::SpiReadReply { succeeded: false, data: 0 })
-            }
-        }
+        &kern::SpiReadRequest { busno } => match spi::read(busno as u8) {
+            Ok(data) => kern_send(&kern::SpiReadReply {
+                succeeded: true,
+                data: data,
+            }),
+            Err(_) => kern_send(&kern::SpiReadReply {
+                succeeded: false,
+                data: 0,
+            }),
+        },
 
-        _ => return Ok(false)
-    }.and(Ok(true))
+        _ => return Ok(false),
+    }
+    .and(Ok(true))
 }

--- a/artiq/test/libartiq_support/lib.rs
+++ b/artiq/test/libartiq_support/lib.rs
@@ -9,46 +9,14 @@ extern crate unwind;
 // Note: this does *not* match the cslice crate!
 // ARTIQ Python has the slice length field fixed at 32 bits, even on 64-bit platforms.
 mod cslice {
-    use core::convert::AsRef;
     use core::marker::PhantomData;
-    use core::slice;
 
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct CSlice<'a, T> {
         base: *const T,
         len: u32,
-        phantom: PhantomData<&'a ()>,
-    }
-
-    impl<'a, T> CSlice<'a, T> {
-        pub fn len(&self) -> usize {
-            self.len as usize
-        }
-
-        pub fn as_ptr(&self) -> *const T {
-            self.base
-        }
-    }
-
-    impl<'a, T> AsRef<[T]> for CSlice<'a, T> {
-        fn as_ref(&self) -> &[T] {
-            unsafe { slice::from_raw_parts(self.base, self.len as usize) }
-        }
-    }
-
-    pub trait AsCSlice<'a, T> {
-        fn as_c_slice(&'a self) -> CSlice<'a, T>;
-    }
-
-    impl<'a> AsCSlice<'a, u8> for str {
-        fn as_c_slice(&'a self) -> CSlice<'a, u8> {
-            CSlice {
-                base: self.as_ptr(),
-                len: self.len() as u32,
-                phantom: PhantomData,
-            }
-        }
+        marker: PhantomData<&'a ()>,
     }
 }
 
@@ -62,7 +30,7 @@ pub mod eh {
 #[path = "../../firmware/ksupport/eh_artiq.rs"]
 pub mod eh_artiq;
 
-use std::{process, str};
+use std::process;
 
 fn terminate(
     exceptions: &'static [Option<eh_artiq::Exception<'static>>],
@@ -75,14 +43,14 @@ fn terminate(
         println!(
             "Uncaught {}: {} ({}, {}, {})",
             exception.id,
-            str::from_utf8(exception.message.as_ref()).unwrap(),
+            exception.message.as_str().unwrap().unwrap(),
             exception.param[0],
             exception.param[1],
             exception.param[2]
         );
         println!(
             "at {}:{}:{}",
-            str::from_utf8(exception.file.as_ref()).unwrap(),
+            exception.file.as_str().unwrap().unwrap(),
             exception.line,
             exception.column
         );

--- a/artiq/test/libartiq_support/lib.rs
+++ b/artiq/test/libartiq_support/lib.rs
@@ -2,15 +2,15 @@
 #![crate_name = "artiq_support"]
 #![crate_type = "cdylib"]
 
-extern crate std as core;
 extern crate libc;
+extern crate std as core;
 extern crate unwind;
 
 // Note: this does *not* match the cslice crate!
 // ARTIQ Python has the slice length field fixed at 32 bits, even on 64-bit platforms.
 mod cslice {
-    use core::marker::PhantomData;
     use core::convert::AsRef;
+    use core::marker::PhantomData;
     use core::slice;
 
     #[repr(C)]
@@ -18,7 +18,7 @@ mod cslice {
     pub struct CSlice<'a, T> {
         base: *const T,
         len: u32,
-        phantom: PhantomData<&'a ()>
+        phantom: PhantomData<&'a ()>,
     }
 
     impl<'a, T> CSlice<'a, T> {
@@ -33,9 +33,7 @@ mod cslice {
 
     impl<'a, T> AsRef<[T]> for CSlice<'a, T> {
         fn as_ref(&self) -> &[T] {
-            unsafe {
-                slice::from_raw_parts(self.base, self.len as usize)
-            }
+            unsafe { slice::from_raw_parts(self.base, self.len as usize) }
         }
     }
 
@@ -48,7 +46,7 @@ mod cslice {
             CSlice {
                 base: self.as_ptr(),
                 len: self.len() as u32,
-                phantom: PhantomData
+                phantom: PhantomData,
             }
         }
     }
@@ -64,24 +62,30 @@ pub mod eh {
 #[path = "../../firmware/ksupport/eh_artiq.rs"]
 pub mod eh_artiq;
 
-use std::{str, process};
+use std::{process, str};
 
-fn terminate(exceptions: &'static [Option<eh_artiq::Exception<'static>>],
-             _stack_pointers: &'static [eh_artiq::StackPointerBacktrace],
-             _backtrace: &'static mut [(usize, usize)]) -> ! {
+fn terminate(
+    exceptions: &'static [Option<eh_artiq::Exception<'static>>],
+    _stack_pointers: &'static [eh_artiq::StackPointerBacktrace],
+    _backtrace: &'static mut [(usize, usize)],
+) -> ! {
     println!("{}", exceptions.len());
     for exception in exceptions.iter() {
         let exception = exception.as_ref().unwrap();
-        println!("Uncaught {}: {} ({}, {}, {})",
-                 exception.id,
-                 str::from_utf8(exception.message.as_ref()).unwrap(),
-                 exception.param[0],
-                 exception.param[1],
-                 exception.param[2]);
-        println!("at {}:{}:{}",
-                 str::from_utf8(exception.file.as_ref()).unwrap(),
-                 exception.line,
-                 exception.column);
+        println!(
+            "Uncaught {}: {} ({}, {}, {})",
+            exception.id,
+            str::from_utf8(exception.message.as_ref()).unwrap(),
+            exception.param[0],
+            exception.param[1],
+            exception.param[2]
+        );
+        println!(
+            "at {}:{}:{}",
+            str::from_utf8(exception.file.as_ref()).unwrap(),
+            exception.line,
+            exception.column
+        );
     }
     process::exit(1);
 }


### PR DESCRIPTION
For review, only look at the second commit.

Previously, exceptions created a `CSlice` with length `usize::MAX` as a sentinel for a host string key, which is unsound, for the most obvious reason of no slice possibly being this long, among others.